### PR TITLE
fix: guide incoming call setup

### DIFF
--- a/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/DefaultPhoneScreen.kt
+++ b/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/DefaultPhoneScreen.kt
@@ -1,85 +1,137 @@
 package dev.alenajam.opendialer.feature.appShell
 
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Phone
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.Button
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SetupScreen(
+    isDefaultPhoneApp: Boolean,
+    hasFullScreenIntentAccess: Boolean,
+    onSetAsDefault: () -> Unit,
+    onEnableFullScreenIntent: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(stringResource(R.string.setup_title)) })
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.setup_description),
+                modifier = Modifier.fillMaxWidth(),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    fontWeight = FontWeight.Normal,
+                ),
+            )
+            Spacer(Modifier.height(16.dp))
+            SetupStep(
+                stepNumber = 1,
+                state = if (isDefaultPhoneApp) SetupStepState.COMPLETE else SetupStepState.CURRENT,
+                title = stringResource(R.string.setup_default_phone_title),
+                description = stringResource(R.string.setup_default_phone_description),
+                actionLabel = stringResource(R.string.setup_default_phone_action),
+                onAction = onSetAsDefault,
+            )
+            Spacer(Modifier.height(12.dp))
+            SetupStep(
+                stepNumber = 2,
+                state = when {
+                    hasFullScreenIntentAccess -> SetupStepState.COMPLETE
+                    isDefaultPhoneApp -> SetupStepState.CURRENT
+                    else -> SetupStepState.NEXT
+                },
+                title = stringResource(R.string.setup_full_screen_title),
+                description = stringResource(R.string.setup_full_screen_description),
+                actionLabel = stringResource(R.string.setup_full_screen_action),
+                onAction = onEnableFullScreenIntent,
+            )
+        }
+    }
+}
 
 @Composable
-internal fun DefaultPhoneScreen(onSetAsDefault: () -> Unit) {
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
+private fun SetupStep(
+    stepNumber: Int,
+    state: SetupStepState,
+    title: String,
+    description: String,
+    actionLabel: String,
+    onAction: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = when (state) {
+                SetupStepState.COMPLETE -> MaterialTheme.colorScheme.surfaceContainerLow
+                SetupStepState.CURRENT -> MaterialTheme.colorScheme.surfaceContainerHigh
+                SetupStepState.NEXT -> MaterialTheme.colorScheme.surfaceContainerLow
+            },
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.5.dp),
     ) {
-        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-            val isCompactHeight = maxHeight < 720.dp
-            val verticalPadding = if (isCompactHeight) 24.dp else 48.dp
-            val illustrationSize = if (isCompactHeight) 180.dp else 280.dp
-            val illustrationSpacing = if (isCompactHeight) 24.dp else 64.dp
-            val titleSpacing = if (isCompactHeight) 12.dp else 20.dp
-            val buttonSpacing = if (isCompactHeight) 20.dp else 28.dp
-
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 32.dp, vertical = verticalPadding),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-            ) {
-                DefaultPhoneIllustration(illustrationSize = illustrationSize)
-                Spacer(Modifier.height(illustrationSpacing))
+        Column(modifier = Modifier.padding(20.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                StepMarker(stepNumber = stepNumber, state = state)
+                Spacer(Modifier.size(16.dp))
                 Text(
-                    text = stringResource(R.string.default_phone_title),
-                    color = MaterialTheme.colorScheme.onBackground,
-                    style = MaterialTheme.typography.headlineMedium,
-                    textAlign = TextAlign.Center,
+                    text = title,
+                    modifier = Modifier.weight(1f),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    style = MaterialTheme.typography.titleMedium,
                 )
-                Spacer(Modifier.height(titleSpacing))
-                Text(
-                    text = stringResource(R.string.default_phone_description),
-                    modifier = Modifier.fillMaxWidth(),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    style = MaterialTheme.typography.titleMedium.copy(
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.Normal,
-                    ),
-                    textAlign = TextAlign.Center,
-                )
-                Spacer(Modifier.height(buttonSpacing))
+            }
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = description,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            if (state == SetupStepState.CURRENT) {
+                Spacer(Modifier.height(12.dp))
                 Button(
-                    onClick = onSetAsDefault,
+                    onClick = onAction,
+                    modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(24.dp),
                 ) {
-                    Text(
-                        text = stringResource(R.string.default_phone_button),
-                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp),
-                    )
+                    Text(text = actionLabel)
                 }
             }
         }
@@ -87,56 +139,38 @@ internal fun DefaultPhoneScreen(onSetAsDefault: () -> Unit) {
 }
 
 @Composable
-private fun DefaultPhoneIllustration(illustrationSize: androidx.compose.ui.unit.Dp) {
-    val outline = MaterialTheme.colorScheme.outline
-    val primaryContainer = MaterialTheme.colorScheme.primaryContainer
-    val primary = MaterialTheme.colorScheme.primary
-    val success = MaterialTheme.colorScheme.tertiary
-    val error = MaterialTheme.colorScheme.error
-    val accent = MaterialTheme.colorScheme.secondary
-    val shadow = MaterialTheme.colorScheme.surfaceContainerHighest
-
-    androidx.compose.foundation.layout.Box(
-        modifier = Modifier.size(illustrationSize),
-        contentAlignment = Alignment.Center,
+private fun StepMarker(stepNumber: Int, state: SetupStepState) {
+    val isComplete = state == SetupStepState.COMPLETE
+    Surface(
+        modifier = Modifier.size(40.dp),
+        shape = RoundedCornerShape(20.dp),
+        color = when (state) {
+            SetupStepState.COMPLETE -> MaterialTheme.colorScheme.tertiary
+            SetupStepState.CURRENT -> MaterialTheme.colorScheme.primary
+            SetupStepState.NEXT -> MaterialTheme.colorScheme.surfaceVariant
+        },
     ) {
-        Canvas(Modifier.fillMaxSize()) {
-            drawOval(
-                color = outline,
-                topLeft = Offset(size.width * .08f, size.height * .18f),
-                size = Size(size.width * .30f, size.height * .48f),
-                style = Stroke(width = 4.dp.toPx()),
-            )
-            drawCircle(success, radius = 22.dp.toPx(), center = Offset(size.width * .10f, size.height * .47f))
-            drawRect(error, topLeft = Offset(size.width * .53f, size.height * .12f), size = Size(34.dp.toPx(), 34.dp.toPx()))
-            drawArc(accent, 72f, 180f, true, Offset(-8.dp.toPx(), size.height * .62f), Size(88.dp.toPx(), 88.dp.toPx()))
-            drawOval(shadow, Offset(size.width * .35f, size.height * .82f), Size(size.width * .34f, 20.dp.toPx()))
-
-            val triangle = Path().apply {
-                moveTo(size.width * .82f, size.height * .42f)
-                lineTo(size.width * .98f, size.height * .42f)
-                lineTo(size.width * .82f, size.height * .58f)
-                close()
-            }
-            drawPath(triangle, color = outline, style = Stroke(width = 4.dp.toPx()))
-            drawRect(
-                color = outline,
-                topLeft = Offset(size.width * .79f, size.height * .69f),
-                size = Size(size.width * .18f, size.height * .08f),
-                style = Stroke(width = 4.dp.toPx()),
-            )
-        }
-        Surface(
-            modifier = Modifier.size(132.dp),
-            shape = androidx.compose.foundation.shape.CircleShape,
-            color = primaryContainer,
-        ) {
+        if (isComplete) {
             Icon(
-                imageVector = Icons.Filled.Phone,
-                contentDescription = null,
-                modifier = Modifier.padding(34.dp),
-                tint = primary,
+                imageVector = Icons.Filled.CheckCircle,
+                contentDescription = stringResource(R.string.setup_step_complete),
+                modifier = Modifier.padding(9.dp),
+                tint = MaterialTheme.colorScheme.onTertiary,
+            )
+        } else {
+            Text(
+                text = stepNumber.toString(),
+                modifier = Modifier.padding(top = 8.dp),
+                color = if (state == SetupStepState.CURRENT) {
+                    MaterialTheme.colorScheme.onPrimary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center,
             )
         }
     }
 }
+
+private enum class SetupStepState { COMPLETE, CURRENT, NEXT }

--- a/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/DefaultPhoneScreen.kt
+++ b/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/DefaultPhoneScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -36,7 +37,9 @@ import androidx.compose.ui.unit.dp
 internal fun SetupScreen(
     isDefaultPhoneApp: Boolean,
     hasFullScreenIntentAccess: Boolean,
+    showDefaultPhoneRecovery: Boolean,
     onSetAsDefault: () -> Unit,
+    onOpenAppInfo: () -> Unit,
     onEnableFullScreenIntent: () -> Unit,
 ) {
     Scaffold(
@@ -68,6 +71,17 @@ internal fun SetupScreen(
                 description = stringResource(R.string.setup_default_phone_description),
                 actionLabel = stringResource(R.string.setup_default_phone_action),
                 onAction = onSetAsDefault,
+                assistanceDescription = if (showDefaultPhoneRecovery) {
+                    stringResource(R.string.setup_default_phone_restricted_description)
+                } else {
+                    null
+                },
+                assistanceActionLabel = if (showDefaultPhoneRecovery) {
+                    stringResource(R.string.setup_default_phone_restricted_action)
+                } else {
+                    null
+                },
+                onAssistanceAction = onOpenAppInfo,
             )
             Spacer(Modifier.height(12.dp))
             SetupStep(
@@ -94,6 +108,9 @@ private fun SetupStep(
     description: String,
     actionLabel: String,
     onAction: () -> Unit,
+    assistanceDescription: String? = null,
+    assistanceActionLabel: String? = null,
+    onAssistanceAction: () -> Unit = {},
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -132,6 +149,22 @@ private fun SetupStep(
                     shape = RoundedCornerShape(24.dp),
                 ) {
                     Text(text = actionLabel)
+                }
+                if (assistanceDescription != null && assistanceActionLabel != null) {
+                    Spacer(Modifier.height(16.dp))
+                    Text(
+                        text = assistanceDescription,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    OutlinedButton(
+                        onClick = onAssistanceAction,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(24.dp),
+                    ) {
+                        Text(text = assistanceActionLabel)
+                    }
                 }
             }
         }

--- a/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/DialerApp.kt
+++ b/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/DialerApp.kt
@@ -73,6 +73,7 @@ fun DialerApp(
         var hasFullScreenIntentAccess by remember(activity) {
             mutableStateOf(activity.canUseFullScreenIntent())
         }
+        var defaultPhoneRequestWasDenied by remember { mutableStateOf(false) }
         val lifecycleOwner = LocalLifecycleOwner.current
 
         fun refreshSetupState() {
@@ -82,7 +83,10 @@ fun DialerApp(
 
         val defaultPhoneLauncher = rememberLauncherForActivityResult(
             contract = ActivityResultContracts.StartActivityForResult(),
-            onResult = { refreshSetupState() }
+            onResult = {
+                refreshSetupState()
+                defaultPhoneRequestWasDenied = !isDefaultPhoneApp
+            }
         )
         val fullScreenIntentLauncher = rememberLauncherForActivityResult(
             contract = ActivityResultContracts.StartActivityForResult(),
@@ -103,10 +107,19 @@ fun DialerApp(
             SetupScreen(
                 isDefaultPhoneApp = isDefaultPhoneApp,
                 hasFullScreenIntentAccess = hasFullScreenIntentAccess,
+                showDefaultPhoneRecovery = defaultPhoneRequestWasDenied && !isDefaultPhoneApp,
                 onSetAsDefault = {
+                    defaultPhoneRequestWasDenied = false
                     defaultPhoneManager.createRequestDefaultDialerIntent()?.let { intent ->
                         defaultPhoneLauncher.launch(intent)
                     }
+                },
+                onOpenAppInfo = {
+                    activity?.startActivity(
+                        Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                            data = Uri.fromParts("package", activity.packageName, null)
+                        }
+                    )
                 },
                 onEnableFullScreenIntent = {
                     activity?.let {

--- a/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/DialerApp.kt
+++ b/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/DialerApp.kt
@@ -1,6 +1,10 @@
 package dev.alenajam.opendialer.feature.appShell
 
+import android.app.NotificationManager
 import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
 import android.telecom.PhoneAccount
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -66,30 +70,51 @@ fun DialerApp(
         var isDefaultPhoneApp by remember(activity) {
             mutableStateOf(defaultPhoneManager.isDefaultDialer())
         }
+        var hasFullScreenIntentAccess by remember(activity) {
+            mutableStateOf(activity.canUseFullScreenIntent())
+        }
         val lifecycleOwner = LocalLifecycleOwner.current
 
-        val launcher = rememberLauncherForActivityResult(
+        fun refreshSetupState() {
+            isDefaultPhoneApp = defaultPhoneManager.isDefaultDialer()
+            hasFullScreenIntentAccess = activity.canUseFullScreenIntent()
+        }
+
+        val defaultPhoneLauncher = rememberLauncherForActivityResult(
             contract = ActivityResultContracts.StartActivityForResult(),
-            onResult = {
-                isDefaultPhoneApp = defaultPhoneManager.isDefaultDialer()
-            }
+            onResult = { refreshSetupState() }
+        )
+        val fullScreenIntentLauncher = rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.StartActivityForResult(),
+            onResult = { refreshSetupState() }
         )
 
         DisposableEffect(activity, lifecycleOwner) {
             val observer = LifecycleEventObserver { _, event ->
                 if (event == Lifecycle.Event.ON_RESUME) {
-                    isDefaultPhoneApp = defaultPhoneManager.isDefaultDialer()
+                    refreshSetupState()
                 }
             }
             lifecycleOwner.lifecycle.addObserver(observer)
             onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
         }
 
-        if (!isDefaultPhoneApp) {
-            DefaultPhoneScreen(
+        if (!isDefaultPhoneApp || !hasFullScreenIntentAccess) {
+            SetupScreen(
+                isDefaultPhoneApp = isDefaultPhoneApp,
+                hasFullScreenIntentAccess = hasFullScreenIntentAccess,
                 onSetAsDefault = {
                     defaultPhoneManager.createRequestDefaultDialerIntent()?.let { intent ->
-                        launcher.launch(intent)
+                        defaultPhoneLauncher.launch(intent)
+                    }
+                },
+                onEnableFullScreenIntent = {
+                    activity?.let {
+                        fullScreenIntentLauncher.launch(
+                            Intent(Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT).apply {
+                                data = Uri.parse("package:${it.packageName}")
+                            }
+                        )
                     }
                 },
             )
@@ -160,6 +185,10 @@ fun DialerApp(
         }
     }
 }
+
+private fun android.app.Activity?.canUseFullScreenIntent(): Boolean =
+    Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE ||
+            this?.getSystemService(NotificationManager::class.java)?.canUseFullScreenIntent() == true
 
 @Composable
 private fun HandleDialIntent(onOpenContactsSearch: (prefilledNumber: String) -> Unit) {

--- a/feature/appShell/src/main/res/values-ar/strings.xml
+++ b/feature/appShell/src/main/res/values-ar/strings.xml
@@ -9,4 +9,13 @@
     <string name="default_phone_title" comment="Title of the prompt asking the user to make OpenDialer the default phone app.">اجعل OpenDialer تطبيق الهاتف الافتراضي</string>
     <string name="default_phone_description" comment="Explanation that calling requires OpenDialer to be the default phone app.">لا يمكن لـ OpenDialer إجراء المكالمات واستقبالها إلا عند تعيينه تطبيق الهاتف الافتراضي.</string>
     <string name="default_phone_button" comment="Button that opens the system flow for choosing the default phone app.">تعيين كتطبيق افتراضي</string>
+    <string name="setup_title" comment="Title of the guided phone-app setup.">إعداد OpenDialer</string>
+    <string name="setup_description" comment="Explanation for the guided setup steps.">أكمل هذه الخطوات لضمان عمل المكالمات بشكل موثوق.</string>
+    <string name="setup_default_phone_title" comment="First setup step title.">اجعل OpenDialer تطبيق الهاتف لديك</string>
+    <string name="setup_default_phone_description" comment="First setup step explanation.">يتيح ذلك لـ OpenDialer إجراء المكالمات واستقبالها.</string>
+    <string name="setup_default_phone_action" comment="First setup step button.">اختر تطبيق الهاتف</string>
+    <string name="setup_full_screen_title" comment="Second setup step title.">عرض المكالمات الواردة بملء الشاشة</string>
+    <string name="setup_full_screen_description" comment="Second setup step explanation.">تُفتح المكالمات الواردة فوق شاشة القفل لتتمكن من الرد فورًا.</string>
+    <string name="setup_full_screen_action" comment="Second setup step button.">السماح بملء الشاشة</string>
+    <string name="setup_step_complete" comment="Accessibility label for a completed setup step.">مكتمل</string>
 </resources>

--- a/feature/appShell/src/main/res/values-ar/strings.xml
+++ b/feature/appShell/src/main/res/values-ar/strings.xml
@@ -14,6 +14,8 @@
     <string name="setup_default_phone_title" comment="First setup step title.">اجعل OpenDialer تطبيق الهاتف لديك</string>
     <string name="setup_default_phone_description" comment="First setup step explanation.">يتيح ذلك لـ OpenDialer إجراء المكالمات واستقبالها.</string>
     <string name="setup_default_phone_action" comment="First setup step button.">اختر تطبيق الهاتف</string>
+    <string name="setup_default_phone_restricted_description" comment="Help shown when Android blocks the default-phone request.">إذا لم يسمح لك Android باختيار OpenDialer، افتح معلومات التطبيق. من القائمة، اسمح بالإعدادات المقيّدة ثم حاول مرة أخرى.</string>
+    <string name="setup_default_phone_restricted_action" comment="Button that opens the system App info page.">فتح معلومات التطبيق</string>
     <string name="setup_full_screen_title" comment="Second setup step title.">عرض المكالمات الواردة بملء الشاشة</string>
     <string name="setup_full_screen_description" comment="Second setup step explanation.">تُفتح المكالمات الواردة فوق شاشة القفل لتتمكن من الرد فورًا.</string>
     <string name="setup_full_screen_action" comment="Second setup step button.">السماح بملء الشاشة</string>

--- a/feature/appShell/src/main/res/values-da/strings.xml
+++ b/feature/appShell/src/main/res/values-da/strings.xml
@@ -9,4 +9,13 @@
     <string name="default_phone_title" comment="Title of the prompt asking the user to make OpenDialer the default phone app.">Gør OpenDialer til standardtelefonapp</string>
     <string name="default_phone_description" comment="Explanation that calling requires OpenDialer to be the default phone app.">OpenDialer kan kun foretage og modtage opkald, når appen er din standardtelefonapp.</string>
     <string name="default_phone_button" comment="Button that opens the system flow for choosing the default phone app.">Angiv som standard</string>
+    <string name="setup_title" comment="Title of the guided phone-app setup.">Opsæt OpenDialer</string>
+    <string name="setup_description" comment="Explanation for the guided setup steps.">Gennemfør disse trin, så opkald fungerer pålideligt.</string>
+    <string name="setup_default_phone_title" comment="First setup step title.">Gør OpenDialer til din telefonapp</string>
+    <string name="setup_default_phone_description" comment="First setup step explanation.">Det giver OpenDialer mulighed for at foretage og modtage opkald.</string>
+    <string name="setup_default_phone_action" comment="First setup step button.">Vælg telefonapp</string>
+    <string name="setup_full_screen_title" comment="Second setup step title.">Vis indgående opkald på fuld skærm</string>
+    <string name="setup_full_screen_description" comment="Second setup step explanation.">Indgående opkald åbnes over låseskærmen, så du kan svare med det samme.</string>
+    <string name="setup_full_screen_action" comment="Second setup step button.">Tillad fuld skærm</string>
+    <string name="setup_step_complete" comment="Accessibility label for a completed setup step.">Fuldført</string>
 </resources>

--- a/feature/appShell/src/main/res/values-da/strings.xml
+++ b/feature/appShell/src/main/res/values-da/strings.xml
@@ -14,6 +14,8 @@
     <string name="setup_default_phone_title" comment="First setup step title.">Gør OpenDialer til din telefonapp</string>
     <string name="setup_default_phone_description" comment="First setup step explanation.">Det giver OpenDialer mulighed for at foretage og modtage opkald.</string>
     <string name="setup_default_phone_action" comment="First setup step button.">Vælg telefonapp</string>
+    <string name="setup_default_phone_restricted_description" comment="Help shown when Android blocks the default-phone request.">Hvis Android ikke lod dig vælge OpenDialer, skal du åbne Appoplysninger. Tillad begrænsede indstillinger i menuen, og prøv derefter igen.</string>
+    <string name="setup_default_phone_restricted_action" comment="Button that opens the system App info page.">Åbn appoplysninger</string>
     <string name="setup_full_screen_title" comment="Second setup step title.">Vis indgående opkald på fuld skærm</string>
     <string name="setup_full_screen_description" comment="Second setup step explanation.">Indgående opkald åbnes over låseskærmen, så du kan svare med det samme.</string>
     <string name="setup_full_screen_action" comment="Second setup step button.">Tillad fuld skærm</string>

--- a/feature/appShell/src/main/res/values-de/strings.xml
+++ b/feature/appShell/src/main/res/values-de/strings.xml
@@ -9,4 +9,13 @@
     <string name="default_phone_title" comment="Title of the prompt asking the user to make OpenDialer the default phone app.">OpenDialer als Standard-Telefon-App festlegen</string>
     <string name="default_phone_description" comment="Explanation that calling requires OpenDialer to be the default phone app.">OpenDialer kann nur Anrufe tätigen und empfangen, wenn es deine Standard-Telefon-App ist.</string>
     <string name="default_phone_button" comment="Button that opens the system flow for choosing the default phone app.">Als Standard festlegen</string>
+    <string name="setup_title" comment="Title of the guided phone-app setup.">OpenDialer einrichten</string>
+    <string name="setup_description" comment="Explanation for the guided setup steps.">Schließe diese Schritte ab, damit Anrufe zuverlässig funktionieren.</string>
+    <string name="setup_default_phone_title" comment="First setup step title.">OpenDialer als Telefon-App festlegen</string>
+    <string name="setup_default_phone_description" comment="First setup step explanation.">Damit kann OpenDialer Anrufe tätigen und empfangen.</string>
+    <string name="setup_default_phone_action" comment="First setup step button.">Telefon-App auswählen</string>
+    <string name="setup_full_screen_title" comment="Second setup step title.">Eingehende Anrufe im Vollbild anzeigen</string>
+    <string name="setup_full_screen_description" comment="Second setup step explanation.">Eingehende Anrufe öffnen sich über dem Sperrbildschirm, damit du sofort antworten kannst.</string>
+    <string name="setup_full_screen_action" comment="Second setup step button.">Vollbild erlauben</string>
+    <string name="setup_step_complete" comment="Accessibility label for a completed setup step.">Abgeschlossen</string>
 </resources>

--- a/feature/appShell/src/main/res/values-de/strings.xml
+++ b/feature/appShell/src/main/res/values-de/strings.xml
@@ -14,6 +14,8 @@
     <string name="setup_default_phone_title" comment="First setup step title.">OpenDialer als Telefon-App festlegen</string>
     <string name="setup_default_phone_description" comment="First setup step explanation.">Damit kann OpenDialer Anrufe tätigen und empfangen.</string>
     <string name="setup_default_phone_action" comment="First setup step button.">Telefon-App auswählen</string>
+    <string name="setup_default_phone_restricted_description" comment="Help shown when Android blocks the default-phone request.">Wenn Android dich OpenDialer nicht auswählen ließ, öffne die App-Info. Erlaube im Menü eingeschränkte Einstellungen und versuche es dann erneut.</string>
+    <string name="setup_default_phone_restricted_action" comment="Button that opens the system App info page.">App-Info öffnen</string>
     <string name="setup_full_screen_title" comment="Second setup step title.">Eingehende Anrufe im Vollbild anzeigen</string>
     <string name="setup_full_screen_description" comment="Second setup step explanation.">Eingehende Anrufe öffnen sich über dem Sperrbildschirm, damit du sofort antworten kannst.</string>
     <string name="setup_full_screen_action" comment="Second setup step button.">Vollbild erlauben</string>

--- a/feature/appShell/src/main/res/values-es/strings.xml
+++ b/feature/appShell/src/main/res/values-es/strings.xml
@@ -9,4 +9,13 @@
     <string name="default_phone_title" comment="Title of the prompt asking the user to make OpenDialer the default phone app.">Establecer OpenDialer como aplicación de teléfono predeterminada</string>
     <string name="default_phone_description" comment="Explanation that calling requires OpenDialer to be the default phone app.">OpenDialer solo puede hacer y recibir llamadas cuando es tu aplicación de teléfono predeterminada.</string>
     <string name="default_phone_button" comment="Button that opens the system flow for choosing the default phone app.">Establecer como predeterminada</string>
+    <string name="setup_title" comment="Title of the guided phone-app setup.">Configura OpenDialer</string>
+    <string name="setup_description" comment="Explanation for the guided setup steps.">Completa estos pasos para que las llamadas funcionen de forma fiable.</string>
+    <string name="setup_default_phone_title" comment="First setup step title.">Haz de OpenDialer tu aplicación de teléfono</string>
+    <string name="setup_default_phone_description" comment="First setup step explanation.">Permite a OpenDialer hacer y recibir llamadas.</string>
+    <string name="setup_default_phone_action" comment="First setup step button.">Elegir aplicación</string>
+    <string name="setup_full_screen_title" comment="Second setup step title.">Mostrar llamadas entrantes a pantalla completa</string>
+    <string name="setup_full_screen_description" comment="Second setup step explanation.">Permite que las llamadas entrantes se abran sobre la pantalla de bloqueo para responder de inmediato.</string>
+    <string name="setup_full_screen_action" comment="Second setup step button.">Permitir pantalla completa</string>
+    <string name="setup_step_complete" comment="Accessibility label for a completed setup step.">Completado</string>
 </resources>

--- a/feature/appShell/src/main/res/values-es/strings.xml
+++ b/feature/appShell/src/main/res/values-es/strings.xml
@@ -14,6 +14,8 @@
     <string name="setup_default_phone_title" comment="First setup step title.">Haz de OpenDialer tu aplicación de teléfono</string>
     <string name="setup_default_phone_description" comment="First setup step explanation.">Permite a OpenDialer hacer y recibir llamadas.</string>
     <string name="setup_default_phone_action" comment="First setup step button.">Elegir aplicación</string>
+    <string name="setup_default_phone_restricted_description" comment="Help shown when Android blocks the default-phone request.">Si Android no te permitió elegir OpenDialer, abre Información de la aplicación. En el menú, permite los ajustes restringidos y vuelve a intentarlo.</string>
+    <string name="setup_default_phone_restricted_action" comment="Button that opens the system App info page.">Abrir información</string>
     <string name="setup_full_screen_title" comment="Second setup step title.">Mostrar llamadas entrantes a pantalla completa</string>
     <string name="setup_full_screen_description" comment="Second setup step explanation.">Permite que las llamadas entrantes se abran sobre la pantalla de bloqueo para responder de inmediato.</string>
     <string name="setup_full_screen_action" comment="Second setup step button.">Permitir pantalla completa</string>

--- a/feature/appShell/src/main/res/values-fr/strings.xml
+++ b/feature/appShell/src/main/res/values-fr/strings.xml
@@ -14,6 +14,8 @@
     <string name="setup_default_phone_title" comment="First setup step title.">Faire d’OpenDialer votre application Téléphone</string>
     <string name="setup_default_phone_description" comment="First setup step explanation.">Cela permet à OpenDialer de passer et recevoir des appels.</string>
     <string name="setup_default_phone_action" comment="First setup step button.">Choisir l’application</string>
+    <string name="setup_default_phone_restricted_description" comment="Help shown when Android blocks the default-phone request.">Si Android ne vous a pas laissé choisir OpenDialer, ouvrez les informations de l’application. Dans le menu, autorisez les paramètres restreints, puis réessayez.</string>
+    <string name="setup_default_phone_restricted_action" comment="Button that opens the system App info page.">Ouvrir les infos</string>
     <string name="setup_full_screen_title" comment="Second setup step title.">Afficher les appels entrants en plein écran</string>
     <string name="setup_full_screen_description" comment="Second setup step explanation.">Les appels entrants s’ouvrent sur l’écran verrouillé afin de répondre immédiatement.</string>
     <string name="setup_full_screen_action" comment="Second setup step button.">Autoriser le plein écran</string>

--- a/feature/appShell/src/main/res/values-fr/strings.xml
+++ b/feature/appShell/src/main/res/values-fr/strings.xml
@@ -9,4 +9,13 @@
     <string name="default_phone_title" comment="Title of the prompt asking the user to make OpenDialer the default phone app.">Définir OpenDialer comme application Téléphone par défaut</string>
     <string name="default_phone_description" comment="Explanation that calling requires OpenDialer to be the default phone app.">OpenDialer ne peut passer et recevoir des appels que lorsqu’elle est votre application Téléphone par défaut.</string>
     <string name="default_phone_button" comment="Button that opens the system flow for choosing the default phone app.">Définir par défaut</string>
+    <string name="setup_title" comment="Title of the guided phone-app setup.">Configurer OpenDialer</string>
+    <string name="setup_description" comment="Explanation for the guided setup steps.">Terminez ces étapes pour assurer le bon fonctionnement des appels.</string>
+    <string name="setup_default_phone_title" comment="First setup step title.">Faire d’OpenDialer votre application Téléphone</string>
+    <string name="setup_default_phone_description" comment="First setup step explanation.">Cela permet à OpenDialer de passer et recevoir des appels.</string>
+    <string name="setup_default_phone_action" comment="First setup step button.">Choisir l’application</string>
+    <string name="setup_full_screen_title" comment="Second setup step title.">Afficher les appels entrants en plein écran</string>
+    <string name="setup_full_screen_description" comment="Second setup step explanation.">Les appels entrants s’ouvrent sur l’écran verrouillé afin de répondre immédiatement.</string>
+    <string name="setup_full_screen_action" comment="Second setup step button.">Autoriser le plein écran</string>
+    <string name="setup_step_complete" comment="Accessibility label for a completed setup step.">Terminé</string>
 </resources>

--- a/feature/appShell/src/main/res/values-it/strings.xml
+++ b/feature/appShell/src/main/res/values-it/strings.xml
@@ -9,4 +9,13 @@
     <string name="default_phone_title" comment="Title of the prompt asking the user to make OpenDialer the default phone app.">Imposta OpenDialer come app Telefono predefinita</string>
     <string name="default_phone_description" comment="Explanation that calling requires OpenDialer to be the default phone app.">OpenDialer può effettuare e ricevere chiamate solo se è l’app Telefono predefinita.</string>
     <string name="default_phone_button" comment="Button that opens the system flow for choosing the default phone app.">Imposta come predefinita</string>
+    <string name="setup_title" comment="Title of the guided phone-app setup.">Configura OpenDialer</string>
+    <string name="setup_description" comment="Explanation for the guided setup steps.">Completa questi passaggi per assicurare il corretto funzionamento delle chiamate.</string>
+    <string name="setup_default_phone_title" comment="First setup step title.">Imposta OpenDialer come app Telefono</string>
+    <string name="setup_default_phone_description" comment="First setup step explanation.">Permette a OpenDialer di effettuare e ricevere chiamate.</string>
+    <string name="setup_default_phone_action" comment="First setup step button.">Scegli l’app Telefono</string>
+    <string name="setup_full_screen_title" comment="Second setup step title.">Mostra le chiamate in arrivo a schermo intero</string>
+    <string name="setup_full_screen_description" comment="Second setup step explanation.">Permette alle chiamate in arrivo di aprirsi sopra la schermata di blocco, per rispondere subito.</string>
+    <string name="setup_full_screen_action" comment="Second setup step button.">Consenti schermo intero</string>
+    <string name="setup_step_complete" comment="Accessibility label for a completed setup step.">Completato</string>
 </resources>

--- a/feature/appShell/src/main/res/values-it/strings.xml
+++ b/feature/appShell/src/main/res/values-it/strings.xml
@@ -14,6 +14,8 @@
     <string name="setup_default_phone_title" comment="First setup step title.">Imposta OpenDialer come app Telefono</string>
     <string name="setup_default_phone_description" comment="First setup step explanation.">Permette a OpenDialer di effettuare e ricevere chiamate.</string>
     <string name="setup_default_phone_action" comment="First setup step button.">Scegli l’app Telefono</string>
+    <string name="setup_default_phone_restricted_description" comment="Help shown when Android blocks the default-phone request.">Se Android non ti ha permesso di scegliere OpenDialer, apri Info app. Nel menu, consenti le impostazioni limitate, poi riprova.</string>
+    <string name="setup_default_phone_restricted_action" comment="Button that opens the system App info page.">Apri Info app</string>
     <string name="setup_full_screen_title" comment="Second setup step title.">Mostra le chiamate in arrivo a schermo intero</string>
     <string name="setup_full_screen_description" comment="Second setup step explanation.">Permette alle chiamate in arrivo di aprirsi sopra la schermata di blocco, per rispondere subito.</string>
     <string name="setup_full_screen_action" comment="Second setup step button.">Consenti schermo intero</string>

--- a/feature/appShell/src/main/res/values-nb/strings.xml
+++ b/feature/appShell/src/main/res/values-nb/strings.xml
@@ -14,6 +14,8 @@
     <string name="setup_default_phone_title" comment="First setup step title.">Gjør OpenDialer til telefonappen din</string>
     <string name="setup_default_phone_description" comment="First setup step explanation.">Dette lar OpenDialer ringe og motta samtaler.</string>
     <string name="setup_default_phone_action" comment="First setup step button.">Velg telefonapp</string>
+    <string name="setup_default_phone_restricted_description" comment="Help shown when Android blocks the default-phone request.">Hvis Android ikke lot deg velge OpenDialer, åpner du Appinfo. Tillat begrensede innstillinger i menyen, og prøv deretter på nytt.</string>
+    <string name="setup_default_phone_restricted_action" comment="Button that opens the system App info page.">Åpne appinfo</string>
     <string name="setup_full_screen_title" comment="Second setup step title.">Vis innkommende samtaler på full skjerm</string>
     <string name="setup_full_screen_description" comment="Second setup step explanation.">Innkommende samtaler åpnes over låseskjermen, slik at du kan svare med en gang.</string>
     <string name="setup_full_screen_action" comment="Second setup step button.">Tillat full skjerm</string>

--- a/feature/appShell/src/main/res/values-nb/strings.xml
+++ b/feature/appShell/src/main/res/values-nb/strings.xml
@@ -9,4 +9,13 @@
     <string name="default_phone_title" comment="Title of the prompt asking the user to make OpenDialer the default phone app.">Angi OpenDialer som standard telefonapp</string>
     <string name="default_phone_description" comment="Explanation that calling requires OpenDialer to be the default phone app.">OpenDialer kan bare ringe og motta samtaler når appen er standard telefonapp.</string>
     <string name="default_phone_button" comment="Button that opens the system flow for choosing the default phone app.">Angi som standard</string>
+    <string name="setup_title" comment="Title of the guided phone-app setup.">Konfigurer OpenDialer</string>
+    <string name="setup_description" comment="Explanation for the guided setup steps.">Fullfør disse trinnene for at samtaler skal fungere pålitelig.</string>
+    <string name="setup_default_phone_title" comment="First setup step title.">Gjør OpenDialer til telefonappen din</string>
+    <string name="setup_default_phone_description" comment="First setup step explanation.">Dette lar OpenDialer ringe og motta samtaler.</string>
+    <string name="setup_default_phone_action" comment="First setup step button.">Velg telefonapp</string>
+    <string name="setup_full_screen_title" comment="Second setup step title.">Vis innkommende samtaler på full skjerm</string>
+    <string name="setup_full_screen_description" comment="Second setup step explanation.">Innkommende samtaler åpnes over låseskjermen, slik at du kan svare med en gang.</string>
+    <string name="setup_full_screen_action" comment="Second setup step button.">Tillat full skjerm</string>
+    <string name="setup_step_complete" comment="Accessibility label for a completed setup step.">Fullført</string>
 </resources>

--- a/feature/appShell/src/main/res/values-nl/strings.xml
+++ b/feature/appShell/src/main/res/values-nl/strings.xml
@@ -14,6 +14,8 @@
     <string name="setup_default_phone_title" comment="First setup step title.">Maak OpenDialer je telefoon-app</string>
     <string name="setup_default_phone_description" comment="First setup step explanation.">Hiermee kan OpenDialer bellen en oproepen ontvangen.</string>
     <string name="setup_default_phone_action" comment="First setup step button.">Telefoon-app kiezen</string>
+    <string name="setup_default_phone_restricted_description" comment="Help shown when Android blocks the default-phone request.">Als Android je OpenDialer niet liet kiezen, open je App-info. Sta in het menu beperkte instellingen toe en probeer het opnieuw.</string>
+    <string name="setup_default_phone_restricted_action" comment="Button that opens the system App info page.">App-info openen</string>
     <string name="setup_full_screen_title" comment="Second setup step title.">Inkomende oproepen schermvullend tonen</string>
     <string name="setup_full_screen_description" comment="Second setup step explanation.">Inkomende oproepen openen boven het vergrendelscherm, zodat je direct kunt opnemen.</string>
     <string name="setup_full_screen_action" comment="Second setup step button.">Schermvullend toestaan</string>

--- a/feature/appShell/src/main/res/values-nl/strings.xml
+++ b/feature/appShell/src/main/res/values-nl/strings.xml
@@ -9,4 +9,13 @@
     <string name="default_phone_title" comment="Title of the prompt asking the user to make OpenDialer the default phone app.">OpenDialer instellen als standaard telefoon-app</string>
     <string name="default_phone_description" comment="Explanation that calling requires OpenDialer to be the default phone app.">OpenDialer kan alleen gesprekken voeren en ontvangen als dit je standaard telefoon-app is.</string>
     <string name="default_phone_button" comment="Button that opens the system flow for choosing the default phone app.">Instellen als standaard</string>
+    <string name="setup_title" comment="Title of the guided phone-app setup.">OpenDialer instellen</string>
+    <string name="setup_description" comment="Explanation for the guided setup steps.">Voltooi deze stappen zodat bellen betrouwbaar werkt.</string>
+    <string name="setup_default_phone_title" comment="First setup step title.">Maak OpenDialer je telefoon-app</string>
+    <string name="setup_default_phone_description" comment="First setup step explanation.">Hiermee kan OpenDialer bellen en oproepen ontvangen.</string>
+    <string name="setup_default_phone_action" comment="First setup step button.">Telefoon-app kiezen</string>
+    <string name="setup_full_screen_title" comment="Second setup step title.">Inkomende oproepen schermvullend tonen</string>
+    <string name="setup_full_screen_description" comment="Second setup step explanation.">Inkomende oproepen openen boven het vergrendelscherm, zodat je direct kunt opnemen.</string>
+    <string name="setup_full_screen_action" comment="Second setup step button.">Schermvullend toestaan</string>
+    <string name="setup_step_complete" comment="Accessibility label for a completed setup step.">Voltooid</string>
 </resources>

--- a/feature/appShell/src/main/res/values-pt/strings.xml
+++ b/feature/appShell/src/main/res/values-pt/strings.xml
@@ -14,6 +14,8 @@
     <string name="setup_default_phone_title" comment="First setup step title.">Definir o OpenDialer como app de telefone</string>
     <string name="setup_default_phone_description" comment="First setup step explanation.">Isso permite que o OpenDialer faça e receba chamadas.</string>
     <string name="setup_default_phone_action" comment="First setup step button.">Escolher app de telefone</string>
+    <string name="setup_default_phone_restricted_description" comment="Help shown when Android blocks the default-phone request.">Se o Android não permitiu escolher o OpenDialer, abra as informações do app. No menu, permita configurações restritas e tente novamente.</string>
+    <string name="setup_default_phone_restricted_action" comment="Button that opens the system App info page.">Abrir informações</string>
     <string name="setup_full_screen_title" comment="Second setup step title.">Mostrar chamadas recebidas em tela cheia</string>
     <string name="setup_full_screen_description" comment="Second setup step explanation.">As chamadas recebidas abrem sobre a tela de bloqueio para que você possa atender imediatamente.</string>
     <string name="setup_full_screen_action" comment="Second setup step button.">Permitir tela cheia</string>

--- a/feature/appShell/src/main/res/values-pt/strings.xml
+++ b/feature/appShell/src/main/res/values-pt/strings.xml
@@ -9,4 +9,13 @@
     <string name="default_phone_title" comment="Title of the prompt asking the user to make OpenDialer the default phone app.">Defina o OpenDialer como app de telefone padrão</string>
     <string name="default_phone_description" comment="Explanation that calling requires OpenDialer to be the default phone app.">O OpenDialer só pode fazer e receber chamadas quando é o app de telefone padrão.</string>
     <string name="default_phone_button" comment="Button that opens the system flow for choosing the default phone app.">Definir como padrão</string>
+    <string name="setup_title" comment="Title of the guided phone-app setup.">Configurar o OpenDialer</string>
+    <string name="setup_description" comment="Explanation for the guided setup steps.">Conclua estas etapas para que as chamadas funcionem de forma confiável.</string>
+    <string name="setup_default_phone_title" comment="First setup step title.">Definir o OpenDialer como app de telefone</string>
+    <string name="setup_default_phone_description" comment="First setup step explanation.">Isso permite que o OpenDialer faça e receba chamadas.</string>
+    <string name="setup_default_phone_action" comment="First setup step button.">Escolher app de telefone</string>
+    <string name="setup_full_screen_title" comment="Second setup step title.">Mostrar chamadas recebidas em tela cheia</string>
+    <string name="setup_full_screen_description" comment="Second setup step explanation.">As chamadas recebidas abrem sobre a tela de bloqueio para que você possa atender imediatamente.</string>
+    <string name="setup_full_screen_action" comment="Second setup step button.">Permitir tela cheia</string>
+    <string name="setup_step_complete" comment="Accessibility label for a completed setup step.">Concluído</string>
 </resources>

--- a/feature/appShell/src/main/res/values-ro/strings.xml
+++ b/feature/appShell/src/main/res/values-ro/strings.xml
@@ -9,4 +9,13 @@
     <string name="default_phone_title" comment="Title of the prompt asking the user to make OpenDialer the default phone app.">Setează OpenDialer ca aplicație de telefon implicită</string>
     <string name="default_phone_description" comment="Explanation that calling requires OpenDialer to be the default phone app.">OpenDialer poate efectua și primi apeluri numai când este aplicația de telefon implicită.</string>
     <string name="default_phone_button" comment="Button that opens the system flow for choosing the default phone app.">Setează ca implicită</string>
+    <string name="setup_title" comment="Title of the guided phone-app setup.">Configurează OpenDialer</string>
+    <string name="setup_description" comment="Explanation for the guided setup steps.">Parcurge acești pași pentru ca apelurile să funcționeze corect.</string>
+    <string name="setup_default_phone_title" comment="First setup step title.">Setează OpenDialer ca aplicație de telefon</string>
+    <string name="setup_default_phone_description" comment="First setup step explanation.">Permite OpenDialer să efectueze și să primească apeluri.</string>
+    <string name="setup_default_phone_action" comment="First setup step button.">Alege aplicația de telefon</string>
+    <string name="setup_full_screen_title" comment="Second setup step title.">Afișează apelurile primite pe tot ecranul</string>
+    <string name="setup_full_screen_description" comment="Second setup step explanation.">Apelurile primite se deschid peste ecranul de blocare, ca să poți răspunde imediat.</string>
+    <string name="setup_full_screen_action" comment="Second setup step button.">Permite ecran complet</string>
+    <string name="setup_step_complete" comment="Accessibility label for a completed setup step.">Finalizat</string>
 </resources>

--- a/feature/appShell/src/main/res/values-ro/strings.xml
+++ b/feature/appShell/src/main/res/values-ro/strings.xml
@@ -14,6 +14,8 @@
     <string name="setup_default_phone_title" comment="First setup step title.">Setează OpenDialer ca aplicație de telefon</string>
     <string name="setup_default_phone_description" comment="First setup step explanation.">Permite OpenDialer să efectueze și să primească apeluri.</string>
     <string name="setup_default_phone_action" comment="First setup step button.">Alege aplicația de telefon</string>
+    <string name="setup_default_phone_restricted_description" comment="Help shown when Android blocks the default-phone request.">Dacă Android nu ți-a permis să alegi OpenDialer, deschide Informații aplicație. În meniu, permite setările restricționate, apoi încearcă din nou.</string>
+    <string name="setup_default_phone_restricted_action" comment="Button that opens the system App info page.">Deschide informațiile</string>
     <string name="setup_full_screen_title" comment="Second setup step title.">Afișează apelurile primite pe tot ecranul</string>
     <string name="setup_full_screen_description" comment="Second setup step explanation.">Apelurile primite se deschid peste ecranul de blocare, ca să poți răspunde imediat.</string>
     <string name="setup_full_screen_action" comment="Second setup step button.">Permite ecran complet</string>

--- a/feature/appShell/src/main/res/values-zh/strings.xml
+++ b/feature/appShell/src/main/res/values-zh/strings.xml
@@ -14,6 +14,8 @@
     <string name="setup_default_phone_title" comment="First setup step title.">将 OpenDialer 设为电话应用</string>
     <string name="setup_default_phone_description" comment="First setup step explanation.">这样 OpenDialer 才能拨打和接听电话。</string>
     <string name="setup_default_phone_action" comment="First setup step button.">选择电话应用</string>
+    <string name="setup_default_phone_restricted_description" comment="Help shown when Android blocks the default-phone request.">如果 Android 不允许您选择 OpenDialer，请打开应用信息。在菜单中允许受限设置，然后重试。</string>
+    <string name="setup_default_phone_restricted_action" comment="Button that opens the system App info page.">打开应用信息</string>
     <string name="setup_full_screen_title" comment="Second setup step title.">全屏显示来电</string>
     <string name="setup_full_screen_description" comment="Second setup step explanation.">来电会显示在锁定屏幕上方，让您可以立即接听。</string>
     <string name="setup_full_screen_action" comment="Second setup step button.">允许全屏显示</string>

--- a/feature/appShell/src/main/res/values-zh/strings.xml
+++ b/feature/appShell/src/main/res/values-zh/strings.xml
@@ -9,4 +9,13 @@
     <string name="default_phone_title" comment="Title of the prompt asking the user to make OpenDialer the default phone app.">将 OpenDialer 设为默认电话应用</string>
     <string name="default_phone_description" comment="Explanation that calling requires OpenDialer to be the default phone app.">只有将 OpenDialer 设为默认电话应用后，才能拨打和接听电话。</string>
     <string name="default_phone_button" comment="Button that opens the system flow for choosing the default phone app.">设为默认</string>
+    <string name="setup_title" comment="Title of the guided phone-app setup.">设置 OpenDialer</string>
+    <string name="setup_description" comment="Explanation for the guided setup steps.">完成这些步骤，确保通话功能可靠运行。</string>
+    <string name="setup_default_phone_title" comment="First setup step title.">将 OpenDialer 设为电话应用</string>
+    <string name="setup_default_phone_description" comment="First setup step explanation.">这样 OpenDialer 才能拨打和接听电话。</string>
+    <string name="setup_default_phone_action" comment="First setup step button.">选择电话应用</string>
+    <string name="setup_full_screen_title" comment="Second setup step title.">全屏显示来电</string>
+    <string name="setup_full_screen_description" comment="Second setup step explanation.">来电会显示在锁定屏幕上方，让您可以立即接听。</string>
+    <string name="setup_full_screen_action" comment="Second setup step button.">允许全屏显示</string>
+    <string name="setup_step_complete" comment="Accessibility label for a completed setup step.">已完成</string>
 </resources>

--- a/feature/appShell/src/main/res/values/strings.xml
+++ b/feature/appShell/src/main/res/values/strings.xml
@@ -9,4 +9,13 @@
     <string name="default_phone_title" comment="Title of the prompt asking the user to make OpenDialer the default phone app.">Set OpenDialer as default</string>
     <string name="default_phone_description" comment="Explanation that calling requires OpenDialer to be the default phone app.">OpenDialer can only make and receive calls when it’s your default phone app.</string>
     <string name="default_phone_button" comment="Button that opens the system flow for choosing the default phone app.">Set as default</string>
+    <string name="setup_title" comment="Title of the guided phone-app setup.">Set up OpenDialer</string>
+    <string name="setup_description" comment="Explanation for the guided setup steps.">Complete these steps so calling works reliably.</string>
+    <string name="setup_default_phone_title" comment="First setup step title.">Make OpenDialer your phone app</string>
+    <string name="setup_default_phone_description" comment="First setup step explanation.">This lets OpenDialer make and receive calls.</string>
+    <string name="setup_default_phone_action" comment="First setup step button.">Choose phone app</string>
+    <string name="setup_full_screen_title" comment="Second setup step title.">Show incoming calls full screen</string>
+    <string name="setup_full_screen_description" comment="Second setup step explanation.">This lets incoming calls open over the lock screen, so you can answer immediately.</string>
+    <string name="setup_full_screen_action" comment="Second setup step button.">Allow full screen</string>
+    <string name="setup_step_complete" comment="Accessibility label for a completed setup step.">Complete</string>
 </resources>

--- a/feature/appShell/src/main/res/values/strings.xml
+++ b/feature/appShell/src/main/res/values/strings.xml
@@ -14,6 +14,8 @@
     <string name="setup_default_phone_title" comment="First setup step title.">Make OpenDialer your phone app</string>
     <string name="setup_default_phone_description" comment="First setup step explanation.">This lets OpenDialer make and receive calls.</string>
     <string name="setup_default_phone_action" comment="First setup step button.">Choose phone app</string>
+    <string name="setup_default_phone_restricted_description" comment="Help shown when Android blocks the default-phone request.">If Android did not let you choose OpenDialer, open App info. In the menu, allow restricted settings, then try again.</string>
+    <string name="setup_default_phone_restricted_action" comment="Button that opens the system App info page.">Open app info</string>
     <string name="setup_full_screen_title" comment="Second setup step title.">Show incoming calls full screen</string>
     <string name="setup_full_screen_description" comment="Second setup step explanation.">This lets incoming calls open over the lock screen, so you can answer immediately.</string>
     <string name="setup_full_screen_action" comment="Second setup step button.">Allow full screen</string>


### PR DESCRIPTION
Guides users through selecting OpenDialer as the default phone app and enabling full-screen incoming-call notifications. Adds recovery guidance for Android restricted settings.