### PR TITLE
fix: show unique contacts in list

### DIFF
--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsData.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsData.kt
@@ -7,25 +7,19 @@ import android.provider.ContactsContract
 
 abstract class ContactsData {
     companion object {
-        val URI: Uri = ContactsContract.CommonDataKinds.Phone.CONTENT_URI
+        val URI: Uri = ContactsContract.Contacts.CONTENT_URI
 
         private val projection = arrayOf(
-            ContactsContract.CommonDataKinds.Phone._ID,
-            ContactsContract.CommonDataKinds.Phone.CONTACT_ID,
-            ContactsContract.CommonDataKinds.Phone.LOOKUP_KEY,
-            ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME,
-            ContactsContract.CommonDataKinds.Phone.STARRED,
-            ContactsContract.CommonDataKinds.Phone.PHOTO_THUMBNAIL_URI,
-            ContactsContract.CommonDataKinds.Phone.NUMBER,
-            ContactsContract.CommonDataKinds.Phone.TYPE,
-            ContactsContract.CommonDataKinds.Phone.LABEL,
+            ContactsContract.Contacts._ID,
+            ContactsContract.Contacts.DISPLAY_NAME,
+            ContactsContract.Contacts.STARRED,
+            ContactsContract.Contacts.PHOTO_THUMBNAIL_URI,
         )
 
         private const val where =
-            "${ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME} IS NOT NULL AND " +
-                "${ContactsContract.CommonDataKinds.Phone.NUMBER} IS NOT NULL"
+            "${ContactsContract.Contacts.DISPLAY_NAME} IS NOT NULL"
         private const val sort =
-            "${ContactsContract.CommonDataKinds.Phone.STARRED} DESC, ${ContactsContract.CommonDataKinds.Phone.SORT_KEY_PRIMARY}"
+            "${ContactsContract.Contacts.STARRED} DESC, ${ContactsContract.Contacts.SORT_KEY_PRIMARY}"
 
         fun getCursor(contentResolver: ContentResolver): Cursor? = contentResolver.query(
             URI,
@@ -35,27 +29,21 @@ abstract class ContactsData {
             sort
         )
 
-        fun getData(cursor: Cursor): List<DialerContactEntity> {
-            val list = mutableListOf<DialerContactEntity>()
+        fun getData(cursor: Cursor): List<DialerContactSummaryEntity> {
+            val list = mutableListOf<DialerContactSummaryEntity>()
             if (cursor.moveToFirst()) {
                 do {
                     list.add(
-                        DialerContactEntity(
-                            dataId = cursor.getLong(
-                                cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone._ID)
-                            ),
-                            id = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.CONTACT_ID)),
-                            name = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME)),
+                        DialerContactSummaryEntity(
+                            id = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.Contacts._ID)),
+                            name = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.Contacts.DISPLAY_NAME)),
                             photoUri = cursor.getString(
                                 cursor.getColumnIndexOrThrow(
-                                    ContactsContract.CommonDataKinds.Phone.PHOTO_THUMBNAIL_URI
+                                    ContactsContract.Contacts.PHOTO_THUMBNAIL_URI
                                 )
                             )
                                 ?.takeIf { it.isNotBlank() },
-                            starred = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.STARRED)),
-                            number = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER)),
-                            phoneType = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.TYPE)),
-                            phoneLabel = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.LABEL)),
+                            starred = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.Contacts.STARRED)),
                         )
                     )
                 } while (cursor.moveToNext())

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsRepository.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsRepository.kt
@@ -3,6 +3,7 @@ package dev.alenajam.opendialer.data.contacts
 import kotlinx.coroutines.flow.Flow
 
 interface ContactsRepository {
-    fun getContacts(): Flow<List<DialerContactEntity>>
+    fun getContacts(): Flow<List<DialerContactSummaryEntity>>
+    fun getFavoriteContacts(): Flow<List<DialerContactEntity>>
     suspend fun toggleFavorite(contactId: Int, isFavorite: Boolean)
 }

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsRepositoryImpl.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsRepositoryImpl.kt
@@ -11,21 +11,39 @@ import javax.inject.Inject
 
 class ContactsRepositoryImpl
 @Inject constructor(private val app: Application) : ContactsRepository {
-    override fun getContacts(): Flow<List<DialerContactEntity>> =
+    override fun getContacts(): Flow<List<DialerContactSummaryEntity>> =
+        observeContacts(
+            uri = ContactsData.URI,
+            getCursor = ContactsData::getCursor,
+            getData = ContactsData::getData,
+        )
+
+    override fun getFavoriteContacts(): Flow<List<DialerContactEntity>> =
+        observeContacts(
+            uri = FavoriteContactsData.URI,
+            getCursor = FavoriteContactsData::getCursor,
+            getData = FavoriteContactsData::getData,
+        )
+
+    private fun <T> observeContacts(
+        uri: android.net.Uri,
+        getCursor: (android.content.ContentResolver) -> android.database.Cursor?,
+        getData: (android.database.Cursor) -> List<T>,
+    ): Flow<List<T>> =
         callbackFlow {
             val observer = object : ContentObserver(null) {
                 override fun onChange(selfChange: Boolean) {
-                    ContactsData.getCursor(app.contentResolver)?.use {
-                        trySend(ContactsData.getData(it))
+                    getCursor(app.contentResolver)?.use {
+                        trySend(getData(it))
                     }
                 }
             }
 
-            app.contentResolver.registerContentObserver(ContactsData.URI, true, observer)
+            app.contentResolver.registerContentObserver(uri, true, observer)
             app.contentResolver.registerContentObserver(ContactsContract.Contacts.CONTENT_URI, true, observer)
 
-            ContactsData.getCursor(app.contentResolver)?.use {
-                trySend(ContactsData.getData(it))
+            getCursor(app.contentResolver)?.use {
+                trySend(getData(it))
             }
 
             awaitClose {

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/DialerContact.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/DialerContact.kt
@@ -12,7 +12,9 @@ class DialerContact(
 ) {
     companion object {
         fun mapList(list: List<DialerContactEntity>): List<DialerContact> {
-            return list.map { map(it) }
+            return list
+                .distinctBy(DialerContactEntity::id)
+                .map { map(it) }
         }
 
         fun map(contact: DialerContactEntity): DialerContact {

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/DialerContactSummary.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/DialerContactSummary.kt
@@ -1,0 +1,20 @@
+package dev.alenajam.opendialer.data.contacts
+
+class DialerContactSummary(
+    val id: Int,
+    val name: String,
+    val starred: Boolean,
+    val image: String?,
+) {
+    companion object {
+        fun mapList(list: List<DialerContactSummaryEntity>): List<DialerContactSummary> =
+            list.map { contact ->
+                DialerContactSummary(
+                    id = contact.id,
+                    name = contact.name,
+                    starred = contact.starred == 1,
+                    image = contact.photoUri,
+                )
+            }
+    }
+}

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/DialerContactSummaryEntity.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/DialerContactSummaryEntity.kt
@@ -1,0 +1,8 @@
+package dev.alenajam.opendialer.data.contacts
+
+class DialerContactSummaryEntity(
+    val id: Int,
+    val name: String,
+    val starred: Int,
+    val photoUri: String?,
+)

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/FavoriteContactsData.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/FavoriteContactsData.kt
@@ -1,0 +1,59 @@
+package dev.alenajam.opendialer.data.contacts
+
+import android.content.ContentResolver
+import android.database.Cursor
+import android.net.Uri
+import android.provider.ContactsContract
+
+abstract class FavoriteContactsData {
+    companion object {
+        val URI: Uri = ContactsContract.CommonDataKinds.Phone.CONTENT_URI
+
+        private val projection = arrayOf(
+            ContactsContract.CommonDataKinds.Phone._ID,
+            ContactsContract.CommonDataKinds.Phone.CONTACT_ID,
+            ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME,
+            ContactsContract.CommonDataKinds.Phone.STARRED,
+            ContactsContract.CommonDataKinds.Phone.PHOTO_THUMBNAIL_URI,
+            ContactsContract.CommonDataKinds.Phone.NUMBER,
+            ContactsContract.CommonDataKinds.Phone.TYPE,
+            ContactsContract.CommonDataKinds.Phone.LABEL,
+        )
+
+        private const val where =
+            "${ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME} IS NOT NULL AND " +
+                "${ContactsContract.CommonDataKinds.Phone.NUMBER} IS NOT NULL AND " +
+                "${ContactsContract.CommonDataKinds.Phone.STARRED} = 1"
+        private const val sort = ContactsContract.CommonDataKinds.Phone.SORT_KEY_PRIMARY
+
+        fun getCursor(contentResolver: ContentResolver): Cursor? = contentResolver.query(
+            URI,
+            projection,
+            where,
+            null,
+            sort,
+        )
+
+        fun getData(cursor: Cursor): List<DialerContactEntity> {
+            val list = mutableListOf<DialerContactEntity>()
+            if (cursor.moveToFirst()) {
+                do {
+                    list.add(
+                        DialerContactEntity(
+                            dataId = cursor.getLong(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone._ID)),
+                            id = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.CONTACT_ID)),
+                            name = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME)),
+                            photoUri = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.PHOTO_THUMBNAIL_URI))
+                                ?.takeIf { it.isNotBlank() },
+                            starred = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.STARRED)),
+                            number = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER)),
+                            phoneType = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.TYPE)),
+                            phoneLabel = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.LABEL)),
+                        )
+                    )
+                } while (cursor.moveToNext())
+            }
+            return list
+        }
+    }
+}

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/FavoriteContactsData.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/FavoriteContactsData.kt
@@ -24,7 +24,10 @@ abstract class FavoriteContactsData {
             "${ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME} IS NOT NULL AND " +
                 "${ContactsContract.CommonDataKinds.Phone.NUMBER} IS NOT NULL AND " +
                 "${ContactsContract.CommonDataKinds.Phone.STARRED} = 1"
-        private const val sort = ContactsContract.CommonDataKinds.Phone.SORT_KEY_PRIMARY
+        private const val sort =
+            "${ContactsContract.CommonDataKinds.Phone.SORT_KEY_PRIMARY}, " +
+                "${ContactsContract.CommonDataKinds.Phone.IS_SUPER_PRIMARY} DESC, " +
+                "${ContactsContract.CommonDataKinds.Phone.IS_PRIMARY} DESC"
 
         fun getCursor(contentResolver: ContentResolver): Cursor? = contentResolver.query(
             URI,

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsViewModel.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsViewModel.kt
@@ -67,7 +67,7 @@ class CallsViewModel
 
         contactsJob?.cancel()
         contactsJob = viewModelScope.launch {
-            contactsRepository.getContacts().collect { contacts ->
+            contactsRepository.getFavoriteContacts().collect { contacts ->
                 _favorites.value = DialerContact.mapList(contacts).filter { it.starred }
                 cacheRepository.invalidate()
                 if (isCacheRunning) refreshContactInfo()

--- a/feature/calls/src/test/java/dev/alenajam/opendialer/feature/calls/CallsViewModelTest.kt
+++ b/feature/calls/src/test/java/dev/alenajam/opendialer/feature/calls/CallsViewModelTest.kt
@@ -16,6 +16,7 @@ import dev.alenajam.opendialer.data.callsCache.CacheRepository
 import dev.alenajam.opendialer.data.callsCache.ContactInfo
 import dev.alenajam.opendialer.data.contacts.ContactsRepository
 import dev.alenajam.opendialer.data.contacts.DialerContactEntity
+import dev.alenajam.opendialer.data.contacts.DialerContactSummaryEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -131,14 +132,16 @@ private class FakeCallPlacementRepository : CallPlacementRepository {
 }
 
 private class FakeContactsRepository : ContactsRepository {
-    private val contacts = MutableStateFlow<List<DialerContactEntity>>(emptyList())
+    private val favoriteContacts = MutableStateFlow<List<DialerContactEntity>>(emptyList())
 
-    override fun getContacts(): Flow<List<DialerContactEntity>> = contacts
+    override fun getContacts(): Flow<List<DialerContactSummaryEntity>> = MutableStateFlow(emptyList())
+
+    override fun getFavoriteContacts(): Flow<List<DialerContactEntity>> = favoriteContacts
 
     override suspend fun toggleFavorite(contactId: Int, isFavorite: Boolean) = Unit
 
     fun emit(contacts: List<DialerContactEntity>) {
-        this.contacts.value = contacts
+        favoriteContacts.value = contacts
     }
 }
 

--- a/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/AddFavoriteScreen.kt
+++ b/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/AddFavoriteScreen.kt
@@ -1,6 +1,5 @@
 package dev.alenajam.opendialer.feature.contacts
 
-import android.telephony.PhoneNumberUtils
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -48,7 +47,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.alenajam.opendialer.core.common.ui.ContactAvatar
 import dev.alenajam.opendialer.core.common.PermissionUtils
-import dev.alenajam.opendialer.data.contacts.DialerContact
+import dev.alenajam.opendialer.data.contacts.DialerContactSummary
 import dev.alenajam.opendialer.feature.contacts.R
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -71,7 +70,7 @@ fun AddFavoriteScreen(
 @Composable
 fun ContactPickerScreen(
     onNavigateBack: () -> Unit,
-    onContactSelected: (DialerContact) -> Unit,
+    onContactSelected: (DialerContactSummary) -> Unit,
     viewModel: ContactsViewModel = hiltViewModel()
 ) {
     val contacts by viewModel.contacts.collectAsStateWithLifecycle()
@@ -91,13 +90,9 @@ fun ContactPickerScreen(
     val items: List<ContactListItem> = remember(contacts, isSearching, searchQuery) {
         val query = searchQuery.trim()
         if (isSearching && query.isNotEmpty()) {
-            val normalizedQuery = PhoneNumberUtils.normalizeNumber(query)
             return@remember contacts
                 .filter { contact ->
-                    contact.name.contains(query, ignoreCase = true) ||
-                        contact.number.contains(query, ignoreCase = true) ||
-                        normalizedQuery.isNotEmpty() && PhoneNumberUtils.normalizeNumber(contact.number)
-                            .contains(normalizedQuery)
+                    contact.name.contains(query, ignoreCase = true)
                 }
                 .sortedBy { it.name }
                 .map { ContactListItem.ContactItem(it) }
@@ -210,7 +205,7 @@ fun ContactPickerScreen(
 
 private sealed class ContactListItem {
     data class Header(val label: String, val isFavorites: Boolean = false) : ContactListItem()
-    data class ContactItem(val contact: DialerContact) : ContactListItem()
+    data class ContactItem(val contact: DialerContactSummary) : ContactListItem()
 }
 
 @Composable
@@ -262,7 +257,7 @@ private fun PermissionPrompt(
 
 @Composable
 private fun FavoritePickerRow(
-    contact: DialerContact,
+    contact: DialerContactSummary,
     onClick: () -> Unit
 ) {
     Surface(
@@ -276,7 +271,7 @@ private fun FavoritePickerRow(
             ContactAvatar(
                 name = contact.name,
                 photoUri = contact.image,
-                colorKey = contact.number,
+                colorKey = contact.id.toString(),
                 modifier = Modifier.size(40.dp)
             )
 
@@ -288,11 +283,6 @@ private fun FavoritePickerRow(
                 Text(
                     text = contact.name,
                     style = MaterialTheme.typography.bodyLarge
-                )
-                Text(
-                    text = contact.number,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }

--- a/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/ContactsScreen.kt
+++ b/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/ContactsScreen.kt
@@ -1,11 +1,7 @@
 package dev.alenajam.opendialer.feature.contacts
 
-import android.provider.ContactsContract
-import android.telephony.PhoneNumberUtils
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,25 +15,18 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.outlined.History
-import androidx.compose.material.icons.automirrored.outlined.Message
-import androidx.compose.material.icons.outlined.Phone
 import androidx.compose.material.icons.outlined.PersonAddAlt1
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -48,16 +37,13 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.alenajam.opendialer.core.common.ui.ContactAvatar
 import dev.alenajam.opendialer.core.common.CommonUtils
 import dev.alenajam.opendialer.core.common.PermissionUtils
-import dev.alenajam.opendialer.core.common.telecom.CallAccount
-import dev.alenajam.opendialer.core.common.telecom.CallPlacementResult
-import dev.alenajam.opendialer.core.common.ui.CallAccountPicker
-import dev.alenajam.opendialer.data.contacts.DialerContact
+import dev.alenajam.opendialer.data.contacts.DialerContactSummary
 
 @Composable
 fun ContactsScreen(
     viewModel: ContactsViewModel = hiltViewModel(),
     searchQuery: String = "",
-    onOpenHistory: (callIds: List<Int>) -> Unit = {},
+    @Suppress("UNUSED_PARAMETER") onOpenHistory: (callIds: List<Int>) -> Unit = {},
 ) {
     val requestPermissions =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
@@ -69,50 +55,12 @@ fun ContactsScreen(
     val contacts = viewModel.contacts.collectAsStateWithLifecycle()
     val hasPermission = viewModel.hasRuntimePermission.collectAsStateWithLifecycle()
     val context = LocalContext.current
-    var openRowKey by remember { mutableStateOf<String?>(null) }
-    var pendingCallNumber by remember { mutableStateOf<String?>(null) }
-    var callAccounts by remember { mutableStateOf<List<CallAccount>?>(null) }
-    val requestCallPermissions = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestMultiplePermissions()
-    ) { result ->
-        if (PermissionUtils.makeCallPermissions.all { result[it] == true }) {
-            viewModel.handleCallRuntimePermissionGranted()
-            pendingCallNumber?.let { number ->
-                when (val placementResult = viewModel.makeCall(number)) {
-                    is CallPlacementResult.AccountSelectionRequired -> {
-                        callAccounts = placementResult.accounts
-                    }
-                    else -> pendingCallNumber = null
-                }
-            }
-        } else {
-            pendingCallNumber = null
-        }
-    }
-
-    fun placeCall(number: String) {
-        when (val result = viewModel.makeCall(number)) {
-            CallPlacementResult.PermissionRequired -> {
-                pendingCallNumber = number
-                requestCallPermissions.launch(PermissionUtils.makeCallPermissions)
-            }
-            is CallPlacementResult.AccountSelectionRequired -> {
-                pendingCallNumber = number
-                callAccounts = result.accounts
-            }
-            else -> Unit
-        }
-    }
     val filteredContacts = if (searchQuery.isBlank()) {
         contacts.value
     } else {
         val trimmedQuery = searchQuery.trim()
-        val normalizedQuery = PhoneNumberUtils.normalizeNumber(trimmedQuery)
         contacts.value.filter { contact ->
-            contact.name.contains(trimmedQuery, ignoreCase = true) ||
-                contact.number.contains(trimmedQuery, ignoreCase = true) ||
-                normalizedQuery.isNotEmpty() && PhoneNumberUtils.normalizeNumber(contact.number)
-                    .contains(normalizedQuery)
+            contact.name.contains(trimmedQuery, ignoreCase = true)
         }
     }
     val groupBySection = searchQuery.isBlank()
@@ -128,23 +76,6 @@ fun ContactsScreen(
     }
 
     Surface(modifier = Modifier.fillMaxSize()) {
-        callAccounts?.let { accounts ->
-            CallAccountPicker(
-                accounts = accounts,
-                onAccountSelected = { account ->
-                    val number = pendingCallNumber ?: return@CallAccountPicker
-                    callAccounts = null
-                    when (val result = viewModel.makeCall(number, account)) {
-                        is CallPlacementResult.AccountSelectionRequired -> callAccounts = result.accounts
-                        else -> Unit
-                    }
-                },
-                onDismiss = {
-                    callAccounts = null
-                    pendingCallNumber = null
-                },
-            )
-        }
         if (!hasPermission.value) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -188,32 +119,18 @@ fun ContactsScreen(
                 key = { item ->
                     when (item) {
                         is ContactsListEntry.Header -> "header-${item.label}"
-                        is ContactsListEntry.Contact ->
-                            "contact-${item.sectionLabel}-${item.contact.dataId}"
+                        is ContactsListEntry.Contact -> "contact-${item.sectionLabel}-${item.contact.id}"
                     }
                 },
             ) { item ->
                 when (item) {
                     is ContactsListEntry.Header -> ContactSectionHeader(item.label, item.isFavorites)
                     is ContactsListEntry.Contact -> {
-                        // A favorite is intentionally shown both here and in its alphabetical section.
-                        // Include the section so each rendered copy owns its expansion state.
-                        val rowKey = "${item.sectionLabel}-${item.contact.dataId}"
-                        val isOpen = openRowKey == rowKey
                         ContactRow(
                             contact = item.contact,
-                            isOpen = isOpen,
                             roundTop = item.isFirstInSection,
                             roundBottom = item.isLastInSection,
-                            onClick = { openRowKey = if (isOpen) null else rowKey },
                             onOpenContact = { viewModel.openContact(item.contact.id) },
-                            onCall = { placeCall(item.contact.number) },
-                            onMessage = { viewModel.sendMessage(item.contact.number) },
-                            onHistory = {
-                                viewModel.getHistoryIds(item.contact.number)
-                                    .takeIf { it.isNotEmpty() }
-                                    ?.let(onOpenHistory)
-                            },
                         )
                     }
                 }
@@ -226,7 +143,7 @@ private sealed class ContactsListEntry {
     data class Header(val label: String, val isFavorites: Boolean = false) : ContactsListEntry()
 
     data class Contact(
-        val contact: DialerContact,
+        val contact: DialerContactSummary,
         val sectionLabel: String,
         val isFirstInSection: Boolean,
         val isLastInSection: Boolean,
@@ -234,14 +151,14 @@ private sealed class ContactsListEntry {
 }
 
 private fun buildContactListItems(
-    contacts: List<DialerContact>,
+    contacts: List<DialerContactSummary>,
     groupBySection: Boolean,
     allContactsLabel: String,
     favoritesLabel: String,
 ): List<ContactsListEntry> = buildList {
     fun addSection(
         label: String,
-        sectionContacts: List<DialerContact>,
+        sectionContacts: List<DialerContactSummary>,
         isFavorites: Boolean = false,
     ) {
         if (sectionContacts.isEmpty()) return
@@ -298,26 +215,16 @@ private fun ContactSectionHeader(label: String, isFavorites: Boolean) {
 
 @Composable
 private fun ContactRow(
-    contact: DialerContact,
-    isOpen: Boolean,
+    contact: DialerContactSummary,
     roundTop: Boolean,
     roundBottom: Boolean,
-    onClick: () -> Unit,
     onOpenContact: () -> Unit,
-    onCall: () -> Unit,
-    onMessage: () -> Unit,
-    onHistory: () -> Unit,
 ) {
-    val resources = LocalContext.current.resources
-    val phoneType = ContactsContract.CommonDataKinds.Phone.getTypeLabel(
-        resources,
-        contact.phoneType,
-        contact.phoneLabel,
-    )
-
     Surface(
-        onClick = onClick,
-        modifier = Modifier.padding(horizontal = 16.dp, vertical = 1.dp),
+        onClick = onOpenContact,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 1.dp),
         shape = RoundedCornerShape(
             topStart = if (roundTop) 20.dp else 2.dp,
             topEnd = if (roundTop) 20.dp else 2.dp,
@@ -327,113 +234,34 @@ private fun ContactRow(
         color = MaterialTheme.colorScheme.surfaceContainerHigh,
         shadowElevation = 0.5.dp,
     ) {
-        Column {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(vertical = 16.dp, horizontal = 16.dp),
-            ) {
-                ContactAvatar(
-                    name = contact.name,
-                    photoUri = contact.image,
-                    colorKey = contact.number,
-                    modifier = Modifier
-                        .size(50.dp)
-                        .clip(CircleShape)
-                        .clickable(onClick = onOpenContact)
-                )
-
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = contact.name,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Text(
-                        text = stringResource(
-                            R.string.contact_phone_subtitle,
-                            phoneType,
-                            contact.number,
-                        ),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-
-                IconButton(onClick = onCall) {
-                    Icon(
-                        Icons.Outlined.Phone,
-                        contentDescription = stringResource(R.string.call_contact),
-                    )
-                }
-            }
-
-            AnimatedVisibility(visible = isOpen) {
-                Column(
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                    verticalArrangement = Arrangement.spacedBy(1.dp),
-                ) {
-                    ContactActionRow(
-                        icon = Icons.AutoMirrored.Outlined.Message,
-                        label = stringResource(R.string.message_contact),
-                        roundTop = true,
-                        onClick = onMessage,
-                    )
-                    ContactActionRow(
-                        icon = Icons.Outlined.History,
-                        label = stringResource(R.string.contact_history),
-                        roundBottom = true,
-                        onClick = onHistory,
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun ContactActionRow(
-    icon: ImageVector,
-    label: String,
-    roundTop: Boolean = false,
-    roundBottom: Boolean = false,
-    onClick: () -> Unit,
-) {
-    Surface(
-        onClick = onClick,
-        modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceContainer,
-        shape = RoundedCornerShape(
-            topStart = if (roundTop) 12.dp else 2.dp,
-            topEnd = if (roundTop) 12.dp else 2.dp,
-            bottomStart = if (roundBottom) 12.dp else 2.dp,
-            bottomEnd = if (roundBottom) 12.dp else 2.dp,
-        ),
-    ) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+            modifier = Modifier.padding(vertical = 10.dp, horizontal = 16.dp),
         ) {
-            Icon(
-                icon,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            ContactAvatar(
+                name = contact.name,
+                photoUri = contact.image,
+                colorKey = contact.id.toString(),
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape),
             )
-            Text(label, style = MaterialTheme.typography.bodyLarge)
+
+            Text(
+                text = contact.name,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }
 
-val contactMock = DialerContact(
-    dataId = 1,
+val contactMock = DialerContactSummary(
     id = 1,
     name = "John Doe",
     starred = false,
     image = null,
-    number = "+39 333 123 4567",
-    phoneType = ContactsContract.CommonDataKinds.Phone.TYPE_MOBILE,
-    phoneLabel = null,
 )
 
 @Preview(showBackground = true)
@@ -441,13 +269,8 @@ val contactMock = DialerContact(
 private fun ContactRowPreview() {
     ContactRow(
         contact = contactMock,
-        isOpen = true,
         roundTop = true,
         roundBottom = true,
-        onClick = {},
         onOpenContact = {},
-        onCall = {},
-        onMessage = {},
-        onHistory = {},
     )
 }

--- a/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/ContactsScreen.kt
+++ b/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/ContactsScreen.kt
@@ -117,11 +117,13 @@ fun ContactsScreen(
     }
     val groupBySection = searchQuery.isBlank()
     val allContactsLabel = stringResource(R.string.all_contacts)
-    val contactListItems = remember(filteredContacts, groupBySection, allContactsLabel) {
+    val favoritesLabel = stringResource(R.string.favorites)
+    val contactListItems = remember(filteredContacts, groupBySection, allContactsLabel, favoritesLabel) {
         buildContactListItems(
             contacts = filteredContacts,
             groupBySection = groupBySection,
             allContactsLabel = allContactsLabel,
+            favoritesLabel = favoritesLabel,
         )
     }
 
@@ -192,7 +194,7 @@ fun ContactsScreen(
                 },
             ) { item ->
                 when (item) {
-                    is ContactsListEntry.Header -> ContactSectionHeader(item.label)
+                    is ContactsListEntry.Header -> ContactSectionHeader(item.label, item.isFavorites)
                     is ContactsListEntry.Contact -> {
                         // A favorite is intentionally shown both here and in its alphabetical section.
                         // Include the section so each rendered copy owns its expansion state.
@@ -221,7 +223,7 @@ fun ContactsScreen(
 }
 
 private sealed class ContactsListEntry {
-    data class Header(val label: String) : ContactsListEntry()
+    data class Header(val label: String, val isFavorites: Boolean = false) : ContactsListEntry()
 
     data class Contact(
         val contact: DialerContact,
@@ -235,10 +237,15 @@ private fun buildContactListItems(
     contacts: List<DialerContact>,
     groupBySection: Boolean,
     allContactsLabel: String,
+    favoritesLabel: String,
 ): List<ContactsListEntry> = buildList {
-    fun addSection(label: String, sectionContacts: List<DialerContact>) {
+    fun addSection(
+        label: String,
+        sectionContacts: List<DialerContact>,
+        isFavorites: Boolean = false,
+    ) {
         if (sectionContacts.isEmpty()) return
-        add(ContactsListEntry.Header(label))
+        add(ContactsListEntry.Header(label, isFavorites))
         sectionContacts.forEachIndexed { index, contact ->
             add(
                 ContactsListEntry.Contact(
@@ -257,7 +264,7 @@ private fun buildContactListItems(
         return@buildList
     }
 
-    addSection("Favorites", sortedContacts.filter { it.starred })
+    addSection(favoritesLabel, sortedContacts.filter { it.starred }, isFavorites = true)
     sortedContacts
         .groupBy { it.name.firstOrNull()?.uppercaseChar()?.toString() ?: "#" }
         .toSortedMap()
@@ -265,14 +272,14 @@ private fun buildContactListItems(
 }
 
 @Composable
-private fun ContactSectionHeader(label: String) {
+private fun ContactSectionHeader(label: String, isFavorites: Boolean) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 8.dp),
     ) {
-        if (label == "Favorites") {
+        if (isFavorites) {
             Icon(
                 imageVector = Icons.Default.Star,
                 contentDescription = null,

--- a/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/ContactsViewModel.kt
+++ b/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/ContactsViewModel.kt
@@ -13,7 +13,7 @@ import dev.alenajam.opendialer.core.common.telecom.CallPlacementResult
 import dev.alenajam.opendialer.data.calls.CallsRepository
 import dev.alenajam.opendialer.data.calls.DialerCallEntity
 import dev.alenajam.opendialer.data.contacts.ContactsRepository
-import dev.alenajam.opendialer.data.contacts.DialerContact
+import dev.alenajam.opendialer.data.contacts.DialerContactSummary
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -28,8 +28,8 @@ class ContactsViewModel
     private val app: Application,
     private val callPlacementRepository: CallPlacementRepository,
 ) : ViewModel() {
-    private val _contacts = MutableStateFlow<List<DialerContact>>(emptyList())
-    val contacts: StateFlow<List<DialerContact>> = _contacts
+    private val _contacts = MutableStateFlow<List<DialerContactSummary>>(emptyList())
+    val contacts: StateFlow<List<DialerContactSummary>> = _contacts
     private val _hasRuntimePermission = MutableStateFlow(false)
     val hasRuntimePermission: StateFlow<Boolean> = _hasRuntimePermission
     private val _calls = MutableStateFlow<List<DialerCallEntity>>(emptyList())
@@ -50,7 +50,7 @@ class ContactsViewModel
         contactsJob?.cancel()
         contactsJob = viewModelScope.launch {
             contactsRepository.getContacts().collect { contacts ->
-                _contacts.value = DialerContact.mapList(contacts)
+                _contacts.value = DialerContactSummary.mapList(contacts)
             }
         }
     }

--- a/feature/contacts/src/test/java/dev/alenajam/opendialer/feature/contacts/ContactsViewModelTest.kt
+++ b/feature/contacts/src/test/java/dev/alenajam/opendialer/feature/contacts/ContactsViewModelTest.kt
@@ -14,6 +14,7 @@ import dev.alenajam.opendialer.data.calls.DialerCall
 import dev.alenajam.opendialer.data.calls.DialerCallEntity
 import dev.alenajam.opendialer.data.contacts.ContactsRepository
 import dev.alenajam.opendialer.data.contacts.DialerContactEntity
+import dev.alenajam.opendialer.data.contacts.DialerContactSummaryEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -77,15 +78,11 @@ class ContactsViewModelTest {
         assertEquals(true, contactsRepository.toggledIsFavorite)
     }
 
-    private fun contactEntity(id: Int, name: String) = DialerContactEntity(
-        dataId = id.toLong(),
+    private fun contactEntity(id: Int, name: String) = DialerContactSummaryEntity(
         id = id,
         name = name,
         starred = 0,
         photoUri = null,
-        number = "123456789",
-        phoneType = 2,
-        phoneLabel = null,
     )
 }
 
@@ -93,12 +90,14 @@ private class PermissionGrantedApplication : Application() {
     override fun checkSelfPermission(permission: String): Int = PackageManager.PERMISSION_GRANTED
 }
 
-private class FakeContactsRepository(contacts: List<DialerContactEntity>) : ContactsRepository {
+private class FakeContactsRepository(contacts: List<DialerContactSummaryEntity>) : ContactsRepository {
     private val contactsFlow = MutableStateFlow(contacts)
     var toggledContactId: Int? = null
     var toggledIsFavorite: Boolean? = null
 
-    override fun getContacts(): Flow<List<DialerContactEntity>> = contactsFlow
+    override fun getContacts(): Flow<List<DialerContactSummaryEntity>> = contactsFlow
+
+    override fun getFavoriteContacts(): Flow<List<DialerContactEntity>> = MutableStateFlow(emptyList())
 
     override suspend fun toggleFavorite(contactId: Int, isFavorite: Boolean) {
         toggledContactId = contactId


### PR DESCRIPTION
Shows one compact row per contact in the contacts list, keeps favorite phone rows available for quick calling, and deduplicates favorites with multiple numbers.