### PR TITLE
feat: show contact details in call header

### DIFF
--- a/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/CallDetailScreen.kt
+++ b/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/CallDetailScreen.kt
@@ -1,5 +1,6 @@
 package dev.alenajam.opendialer.feature.callDetail
 
+import android.provider.ContactsContract
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -243,12 +244,7 @@ private fun TopBar(
                         modifier = Modifier.size(50.dp)
                     )
                     Spacer(modifier = Modifier.size(8.dp))
-                    Text(
-                        text = if (call.isVoicemailNumber) stringResource(R.string.voicemail)
-                        else if (call.isAnonymous()) stringResource(id = R.string.anonymous)
-                        else if (!call.contactInfo.name.isNullOrBlank()) call.contactInfo.name!!
-                        else call.contactInfo.number!!,
-                    )
+                    CallDetailTitle(call)
                 }
             }
         },
@@ -290,6 +286,41 @@ private fun TopBar(
             }
         }
     )
+}
+
+@Composable
+private fun CallDetailTitle(call: DialerCall) {
+    when {
+        call.isVoicemailNumber -> Text(stringResource(R.string.voicemail))
+        call.isAnonymous() -> Text(stringResource(R.string.anonymous))
+        !call.contactInfo.name.isNullOrBlank() -> {
+            val contact = call.contactInfo
+            val phoneType = if (
+                contact.type == ContactsContract.CommonDataKinds.Phone.TYPE_CUSTOM &&
+                !contact.label.isNullOrBlank()
+            ) {
+                contact.label.orEmpty()
+            } else {
+                stringResource(
+                    ContactsContract.CommonDataKinds.Phone.getTypeLabelResource(contact.type ?: 0)
+                )
+            }
+
+            Column {
+                Text(contact.name!!.trim().substringBefore(' '))
+                Text(
+                    text = stringResource(
+                        R.string.call_detail_contact_subtitle,
+                        phoneType,
+                        contact.number.orEmpty(),
+                    ),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        else -> Text(call.contactInfo.number.orEmpty())
+    }
 }
 
 @Composable

--- a/feature/callDetail/src/main/res/values-ar/strings.xml
+++ b/feature/callDetail/src/main/res/values-ar/strings.xml
@@ -23,4 +23,5 @@
     <string name="more_options" comment="Accessibility label for a button that opens additional actions.">المزيد من الخيارات</string>
     <string name="action_call" comment="Button that starts a phone call.">اتصال</string>
     <string name="cancel" comment="Button that dismisses the current dialog without applying changes.">إلغاء</string>
+    <string name="call_detail_contact_subtitle" comment="Contact phone type and number in the call-detail header. %1$s is the phone type and %2$s is the phone number.">%1$s • %2$s</string>
 </resources>

--- a/feature/callDetail/src/main/res/values-da/strings.xml
+++ b/feature/callDetail/src/main/res/values-da/strings.xml
@@ -23,4 +23,5 @@
     <string name="more_options" comment="Accessibility label for a button that opens additional actions.">Flere valgmuligheder</string>
     <string name="action_call" comment="Button that starts a phone call.">Ring</string>
     <string name="cancel" comment="Button that dismisses the current dialog without applying changes.">Annuller</string>
+    <string name="call_detail_contact_subtitle" comment="Contact phone type and number in the call-detail header. %1$s is the phone type and %2$s is the phone number.">%1$s • %2$s</string>
 </resources>

--- a/feature/callDetail/src/main/res/values-de/strings.xml
+++ b/feature/callDetail/src/main/res/values-de/strings.xml
@@ -23,4 +23,5 @@
     <string name="more_options" comment="Accessibility label for a button that opens additional actions.">Weitere Optionen</string>
     <string name="action_call" comment="Button that starts a phone call.">Anrufen</string>
     <string name="cancel" comment="Button that dismisses the current dialog without applying changes.">Abbrechen</string>
+    <string name="call_detail_contact_subtitle" comment="Contact phone type and number in the call-detail header. %1$s is the phone type and %2$s is the phone number.">%1$s • %2$s</string>
 </resources>

--- a/feature/callDetail/src/main/res/values-es/strings.xml
+++ b/feature/callDetail/src/main/res/values-es/strings.xml
@@ -23,4 +23,5 @@
     <string name="more_options" comment="Accessibility label for a button that opens additional actions.">Más opciones</string>
     <string name="action_call" comment="Button that starts a phone call.">Llamar</string>
     <string name="cancel" comment="Button that dismisses the current dialog without applying changes.">Cancelar</string>
+    <string name="call_detail_contact_subtitle" comment="Contact phone type and number in the call-detail header. %1$s is the phone type and %2$s is the phone number.">%1$s • %2$s</string>
 </resources>

--- a/feature/callDetail/src/main/res/values-fr/strings.xml
+++ b/feature/callDetail/src/main/res/values-fr/strings.xml
@@ -23,4 +23,5 @@
     <string name="more_options" comment="Accessibility label for a button that opens additional actions.">Plus d’options</string>
     <string name="action_call" comment="Button that starts a phone call.">Appeler</string>
     <string name="cancel" comment="Button that dismisses the current dialog without applying changes.">Annuler</string>
+    <string name="call_detail_contact_subtitle" comment="Contact phone type and number in the call-detail header. %1$s is the phone type and %2$s is the phone number.">%1$s • %2$s</string>
 </resources>

--- a/feature/callDetail/src/main/res/values-it/strings.xml
+++ b/feature/callDetail/src/main/res/values-it/strings.xml
@@ -23,4 +23,5 @@
     <string name="more_options" comment="Accessibility label for a button that opens additional actions.">Altre opzioni</string>
     <string name="action_call" comment="Button that starts a phone call.">Chiama</string>
     <string name="cancel" comment="Button that dismisses the current dialog without applying changes.">Annulla</string>
+    <string name="call_detail_contact_subtitle" comment="Contact phone type and number in the call-detail header. %1$s is the phone type and %2$s is the phone number.">%1$s • %2$s</string>
 </resources>

--- a/feature/callDetail/src/main/res/values-nb/strings.xml
+++ b/feature/callDetail/src/main/res/values-nb/strings.xml
@@ -23,4 +23,5 @@
     <string name="more_options" comment="Accessibility label for a button that opens additional actions.">Flere alternativer</string>
     <string name="action_call" comment="Button that starts a phone call.">Ring</string>
     <string name="cancel" comment="Button that dismisses the current dialog without applying changes.">Avbryt</string>
+    <string name="call_detail_contact_subtitle" comment="Contact phone type and number in the call-detail header. %1$s is the phone type and %2$s is the phone number.">%1$s • %2$s</string>
 </resources>

--- a/feature/callDetail/src/main/res/values-nl/strings.xml
+++ b/feature/callDetail/src/main/res/values-nl/strings.xml
@@ -23,4 +23,5 @@
     <string name="more_options" comment="Accessibility label for a button that opens additional actions.">Meer opties</string>
     <string name="action_call" comment="Button that starts a phone call.">Bellen</string>
     <string name="cancel" comment="Button that dismisses the current dialog without applying changes.">Annuleren</string>
+    <string name="call_detail_contact_subtitle" comment="Contact phone type and number in the call-detail header. %1$s is the phone type and %2$s is the phone number.">%1$s • %2$s</string>
 </resources>

--- a/feature/callDetail/src/main/res/values-pt/strings.xml
+++ b/feature/callDetail/src/main/res/values-pt/strings.xml
@@ -23,4 +23,5 @@
     <string name="more_options" comment="Accessibility label for a button that opens additional actions.">Mais opções</string>
     <string name="action_call" comment="Button that starts a phone call.">Ligar</string>
     <string name="cancel" comment="Button that dismisses the current dialog without applying changes.">Cancelar</string>
+    <string name="call_detail_contact_subtitle" comment="Contact phone type and number in the call-detail header. %1$s is the phone type and %2$s is the phone number.">%1$s • %2$s</string>
 </resources>

--- a/feature/callDetail/src/main/res/values-ro/strings.xml
+++ b/feature/callDetail/src/main/res/values-ro/strings.xml
@@ -23,4 +23,5 @@
     <string name="more_options" comment="Accessibility label for a button that opens additional actions.">Mai multe opțiuni</string>
     <string name="action_call" comment="Button that starts a phone call.">Apelează</string>
     <string name="cancel" comment="Button that dismisses the current dialog without applying changes.">Anulează</string>
+    <string name="call_detail_contact_subtitle" comment="Contact phone type and number in the call-detail header. %1$s is the phone type and %2$s is the phone number.">%1$s • %2$s</string>
 </resources>

--- a/feature/callDetail/src/main/res/values-zh/strings.xml
+++ b/feature/callDetail/src/main/res/values-zh/strings.xml
@@ -23,4 +23,5 @@
     <string name="more_options" comment="Accessibility label for a button that opens additional actions.">更多选项</string>
     <string name="action_call" comment="Button that starts a phone call.">拨打</string>
     <string name="cancel" comment="Button that dismisses the current dialog without applying changes.">取消</string>
+    <string name="call_detail_contact_subtitle" comment="Contact phone type and number in the call-detail header. %1$s is the phone type and %2$s is the phone number.">%1$s • %2$s</string>
 </resources>

--- a/feature/callDetail/src/main/res/values/strings.xml
+++ b/feature/callDetail/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="more_options" comment="Accessibility label for a button that opens additional actions.">More options</string>
     <string name="action_call" comment="Button that starts a phone call.">Call</string>
     <string name="cancel" comment="Button that dismisses the current dialog without applying changes.">Cancel</string>
+    <string name="call_detail_contact_subtitle" comment="Contact phone type and number in the call-detail header. %1$s is the phone type and %2$s is the phone number.">%1$s • %2$s</string>
 </resources>


### PR DESCRIPTION
Shows a saved contact's first name with a phone type and number subtitle in call detail. Unknown callers display their number only.