### PR TITLE
feat: add profile card to contacts

### DIFF
--- a/core/common/src/main/java/dev/alenajam/opendialer/core/common/CommonUtils.kt
+++ b/core/common/src/main/java/dev/alenajam/opendialer/core/common/CommonUtils.kt
@@ -128,6 +128,33 @@ object CommonUtils {
     }
 
     @JvmStatic
+    fun showProfileDetail(context: Context) {
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            data = ContactsContract.Profile.CONTENT_URI
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
+    }
+
+    @JvmStatic
+    fun shareContact(context: Context, contactId: Int) {
+        val contactUri = Uri.withAppendedPath(
+            ContactsContract.Contacts.CONTENT_VCARD_URI,
+            contactId.toString(),
+        )
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = ContactsContract.Contacts.CONTENT_VCARD_TYPE
+            putExtra(Intent.EXTRA_STREAM, contactUri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        context.startActivity(
+            Intent.createChooser(intent, null).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        )
+    }
+
+    @JvmStatic
     fun setTheme(mode: Int) {
         AppCompatDelegate.setDefaultNightMode(mode)
     }

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsRepository.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsRepository.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface ContactsRepository {
     fun getContacts(): Flow<List<DialerContactSummaryEntity>>
+    fun getProfileContact(): Flow<DialerContactSummaryEntity?>
     fun getFavoriteContacts(): Flow<List<DialerContactEntity>>
     suspend fun toggleFavorite(contactId: Int, isFavorite: Boolean)
 }

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsRepositoryImpl.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsRepositoryImpl.kt
@@ -7,6 +7,7 @@ import android.provider.ContactsContract
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class ContactsRepositoryImpl
@@ -24,6 +25,13 @@ class ContactsRepositoryImpl
             getCursor = FavoriteContactsData::getCursor,
             getData = FavoriteContactsData::getData,
         )
+
+    override fun getProfileContact(): Flow<DialerContactSummaryEntity?> =
+        observeContacts(
+            uri = ProfileContactData.URI,
+            getCursor = ProfileContactData::getCursor,
+            getData = ProfileContactData::getData,
+        ).map { it.firstOrNull() }
 
     private fun <T> observeContacts(
         uri: android.net.Uri,

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ProfileContactData.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ProfileContactData.kt
@@ -1,0 +1,45 @@
+package dev.alenajam.opendialer.data.contacts
+
+import android.content.ContentResolver
+import android.database.Cursor
+import android.net.Uri
+import android.provider.ContactsContract
+
+abstract class ProfileContactData {
+    companion object {
+        val URI: Uri = ContactsContract.Profile.CONTENT_URI
+
+        private val projection = arrayOf(
+            ContactsContract.Contacts._ID,
+            ContactsContract.Contacts.DISPLAY_NAME,
+            ContactsContract.Contacts.PHOTO_THUMBNAIL_URI,
+        )
+
+        fun getCursor(contentResolver: ContentResolver): Cursor? = contentResolver.query(
+            URI,
+            projection,
+            "${ContactsContract.Contacts.DISPLAY_NAME} IS NOT NULL",
+            null,
+            null,
+        )
+
+        fun getData(cursor: Cursor): List<DialerContactSummaryEntity> = buildList {
+            if (cursor.moveToFirst()) {
+                add(
+                    DialerContactSummaryEntity(
+                        id = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.Contacts._ID)),
+                        name = cursor.getString(
+                            cursor.getColumnIndexOrThrow(ContactsContract.Contacts.DISPLAY_NAME)
+                        ),
+                        starred = 0,
+                        photoUri = cursor.getString(
+                            cursor.getColumnIndexOrThrow(
+                                ContactsContract.Contacts.PHOTO_THUMBNAIL_URI
+                            )
+                        )?.takeIf { it.isNotBlank() },
+                    )
+                )
+            }
+        }
+    }
+}

--- a/feature/calls/src/test/java/dev/alenajam/opendialer/feature/calls/CallsViewModelTest.kt
+++ b/feature/calls/src/test/java/dev/alenajam/opendialer/feature/calls/CallsViewModelTest.kt
@@ -136,6 +136,8 @@ private class FakeContactsRepository : ContactsRepository {
 
     override fun getContacts(): Flow<List<DialerContactSummaryEntity>> = MutableStateFlow(emptyList())
 
+    override fun getProfileContact(): Flow<DialerContactSummaryEntity?> = MutableStateFlow(null)
+
     override fun getFavoriteContacts(): Flow<List<DialerContactEntity>> = favoriteContacts
 
     override suspend fun toggleFavorite(contactId: Int, isFavorite: Boolean) = Unit

--- a/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/ContactsScreen.kt
+++ b/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/ContactsScreen.kt
@@ -16,8 +16,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.PersonAddAlt1
+import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -53,6 +55,7 @@ fun ContactsScreen(
         }
 
     val contacts = viewModel.contacts.collectAsStateWithLifecycle()
+    val profileContact = viewModel.profileContact.collectAsStateWithLifecycle()
     val hasPermission = viewModel.hasRuntimePermission.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val filteredContacts = if (searchQuery.isBlank()) {
@@ -113,6 +116,15 @@ fun ContactsScreen(
                         )
                     }
                 }
+                profileContact.value?.let { profile ->
+                    item(key = "profile-contact") {
+                        ProfileContactCard(
+                            contact = profile,
+                            onOpenProfile = viewModel::openProfileContact,
+                            onShareProfile = { viewModel.shareProfileContact(profile.id) },
+                        )
+                    }
+                }
             }
             items(
                 items = contactListItems,
@@ -134,6 +146,57 @@ fun ContactsScreen(
                         )
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProfileContactCard(
+    contact: DialerContactSummary,
+    onOpenProfile: () -> Unit,
+    onShareProfile: () -> Unit,
+) {
+    Surface(
+        onClick = onOpenProfile,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        shadowElevation = 0.5.dp,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp),
+        ) {
+            ContactAvatar(
+                name = contact.name,
+                photoUri = contact.image,
+                colorKey = contact.id.toString(),
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape),
+            )
+            Column {
+                Text(
+                    text = stringResource(R.string.your_info),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = contact.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+            androidx.compose.foundation.layout.Spacer(modifier = Modifier.weight(1f))
+            IconButton(onClick = onShareProfile) {
+                Icon(
+                    imageVector = Icons.Outlined.Share,
+                    contentDescription = stringResource(R.string.share_contact),
+                )
             }
         }
     }

--- a/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/ContactsViewModel.kt
+++ b/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/ContactsViewModel.kt
@@ -30,11 +30,14 @@ class ContactsViewModel
 ) : ViewModel() {
     private val _contacts = MutableStateFlow<List<DialerContactSummary>>(emptyList())
     val contacts: StateFlow<List<DialerContactSummary>> = _contacts
+    private val _profileContact = MutableStateFlow<DialerContactSummary?>(null)
+    val profileContact: StateFlow<DialerContactSummary?> = _profileContact
     private val _hasRuntimePermission = MutableStateFlow(false)
     val hasRuntimePermission: StateFlow<Boolean> = _hasRuntimePermission
     private val _calls = MutableStateFlow<List<DialerCallEntity>>(emptyList())
     private var hasCallRuntimePermission = false
     private var contactsJob: Job? = null
+    private var profileContactJob: Job? = null
     private var callsJob: Job? = null
 
     init {
@@ -51,6 +54,13 @@ class ContactsViewModel
         contactsJob = viewModelScope.launch {
             contactsRepository.getContacts().collect { contacts ->
                 _contacts.value = DialerContactSummary.mapList(contacts)
+            }
+        }
+
+        profileContactJob?.cancel()
+        profileContactJob = viewModelScope.launch {
+            contactsRepository.getProfileContact().collect { profile ->
+                _profileContact.value = profile?.let { DialerContactSummary.mapList(listOf(it)).first() }
             }
         }
     }
@@ -85,6 +95,14 @@ class ContactsViewModel
 
     fun openContact(contactId: Int) {
         CommonUtils.showContactDetail(app, contactId)
+    }
+
+    fun openProfileContact() {
+        CommonUtils.showProfileDetail(app)
+    }
+
+    fun shareProfileContact(contactId: Int) {
+        CommonUtils.shareContact(app, contactId)
     }
 
     fun toggleFavorite(contactId: Int, isFavorite: Boolean) {

--- a/feature/contacts/src/main/res/values-ar/strings.xml
+++ b/feature/contacts/src/main/res/values-ar/strings.xml
@@ -15,4 +15,6 @@
     <string name="search" comment="Accessibility label for starting a search.">بحث</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">المفضلة</string>
     <string name="favorites_permission_prompt" comment="Message shown when contacts permission is required to manage favorites.">لإدارة المفضلة، فعّل إذن جهات الاتصال</string>
+    <string name="your_info" comment="Label for the device owner's contact profile.">معلوماتك</string>
+    <string name="share_contact" comment="Accessibility label for sharing a contact.">مشاركة جهة الاتصال</string>
 </resources>

--- a/feature/contacts/src/main/res/values-da/strings.xml
+++ b/feature/contacts/src/main/res/values-da/strings.xml
@@ -15,4 +15,6 @@
     <string name="search" comment="Accessibility label for starting a search.">Søg</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favoritter</string>
     <string name="favorites_permission_prompt" comment="Message shown when contacts permission is required to manage favorites.">Slå kontakttilladelser til for at administrere favoritter</string>
+    <string name="your_info" comment="Label for the device owner's contact profile.">Dine oplysninger</string>
+    <string name="share_contact" comment="Accessibility label for sharing a contact.">Del kontakt</string>
 </resources>

--- a/feature/contacts/src/main/res/values-de/strings.xml
+++ b/feature/contacts/src/main/res/values-de/strings.xml
@@ -15,4 +15,6 @@
     <string name="search" comment="Accessibility label for starting a search.">Suchen</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favoriten</string>
     <string name="favorites_permission_prompt" comment="Message shown when contacts permission is required to manage favorites.">Aktiviere die Kontaktberechtigung, um Favoriten zu verwalten</string>
+    <string name="your_info" comment="Label for the device owner's contact profile.">Deine Informationen</string>
+    <string name="share_contact" comment="Accessibility label for sharing a contact.">Kontakt teilen</string>
 </resources>

--- a/feature/contacts/src/main/res/values-es/strings.xml
+++ b/feature/contacts/src/main/res/values-es/strings.xml
@@ -15,4 +15,6 @@
     <string name="search" comment="Accessibility label for starting a search.">Buscar</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favoritos</string>
     <string name="favorites_permission_prompt" comment="Message shown when contacts permission is required to manage favorites.">Activa el permiso de contactos para gestionar los favoritos</string>
+    <string name="your_info" comment="Label for the device owner's contact profile.">Tu información</string>
+    <string name="share_contact" comment="Accessibility label for sharing a contact.">Compartir contacto</string>
 </resources>

--- a/feature/contacts/src/main/res/values-fr/strings.xml
+++ b/feature/contacts/src/main/res/values-fr/strings.xml
@@ -15,4 +15,6 @@
     <string name="search" comment="Accessibility label for starting a search.">Rechercher</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favoris</string>
     <string name="favorites_permission_prompt" comment="Message shown when contacts permission is required to manage favorites.">Activez l’autorisation Contacts pour gérer les favoris</string>
+    <string name="your_info" comment="Label for the device owner's contact profile.">Vos informations</string>
+    <string name="share_contact" comment="Accessibility label for sharing a contact.">Partager le contact</string>
 </resources>

--- a/feature/contacts/src/main/res/values-it/strings.xml
+++ b/feature/contacts/src/main/res/values-it/strings.xml
@@ -15,4 +15,6 @@
     <string name="search" comment="Accessibility label for starting a search.">Cerca</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Preferiti</string>
     <string name="favorites_permission_prompt" comment="Message shown when contacts permission is required to manage favorites.">Per gestire i preferiti, consenti l’accesso ai contatti</string>
+    <string name="your_info" comment="Label for the device owner's contact profile.">Le tue informazioni</string>
+    <string name="share_contact" comment="Accessibility label for sharing a contact.">Condividi contatto</string>
 </resources>

--- a/feature/contacts/src/main/res/values-nb/strings.xml
+++ b/feature/contacts/src/main/res/values-nb/strings.xml
@@ -15,4 +15,6 @@
     <string name="search" comment="Accessibility label for starting a search.">Søk</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favoritter</string>
     <string name="favorites_permission_prompt" comment="Message shown when contacts permission is required to manage favorites.">Slå på kontakttillatelsen for å administrere favoritter</string>
+    <string name="your_info" comment="Label for the device owner's contact profile.">Din informasjon</string>
+    <string name="share_contact" comment="Accessibility label for sharing a contact.">Del kontakt</string>
 </resources>

--- a/feature/contacts/src/main/res/values-nl/strings.xml
+++ b/feature/contacts/src/main/res/values-nl/strings.xml
@@ -15,4 +15,6 @@
     <string name="search" comment="Accessibility label for starting a search.">Zoeken</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favorieten</string>
     <string name="favorites_permission_prompt" comment="Message shown when contacts permission is required to manage favorites.">Schakel de machtiging voor contacten in om favorieten te beheren</string>
+    <string name="your_info" comment="Label for the device owner's contact profile.">Jouw gegevens</string>
+    <string name="share_contact" comment="Accessibility label for sharing a contact.">Contact delen</string>
 </resources>

--- a/feature/contacts/src/main/res/values-pt/strings.xml
+++ b/feature/contacts/src/main/res/values-pt/strings.xml
@@ -15,4 +15,6 @@
     <string name="search" comment="Accessibility label for starting a search.">Pesquisar</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favoritos</string>
     <string name="favorites_permission_prompt" comment="Message shown when contacts permission is required to manage favorites.">Ative a permissão de contatos para gerenciar favoritos</string>
+    <string name="your_info" comment="Label for the device owner's contact profile.">Suas informações</string>
+    <string name="share_contact" comment="Accessibility label for sharing a contact.">Partilhar contacto</string>
 </resources>

--- a/feature/contacts/src/main/res/values-ro/strings.xml
+++ b/feature/contacts/src/main/res/values-ro/strings.xml
@@ -15,4 +15,6 @@
     <string name="search" comment="Accessibility label for starting a search.">Caută</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favorite</string>
     <string name="favorites_permission_prompt" comment="Message shown when contacts permission is required to manage favorites.">Activează permisiunea pentru contacte pentru a gestiona favoritele</string>
+    <string name="your_info" comment="Label for the device owner's contact profile.">Informațiile tale</string>
+    <string name="share_contact" comment="Accessibility label for sharing a contact.">Partajează contactul</string>
 </resources>

--- a/feature/contacts/src/main/res/values-zh/strings.xml
+++ b/feature/contacts/src/main/res/values-zh/strings.xml
@@ -15,4 +15,6 @@
     <string name="search" comment="Accessibility label for starting a search.">搜索</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">收藏</string>
     <string name="favorites_permission_prompt" comment="Message shown when contacts permission is required to manage favorites.">要管理收藏，请开启联系人权限</string>
+    <string name="your_info" comment="Label for the device owner's contact profile.">你的信息</string>
+    <string name="share_contact" comment="Accessibility label for sharing a contact.">分享联系人</string>
 </resources>

--- a/feature/contacts/src/main/res/values/strings.xml
+++ b/feature/contacts/src/main/res/values/strings.xml
@@ -15,4 +15,6 @@
     <string name="search" comment="Accessibility label for starting a search.">Search</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favorites</string>
     <string name="favorites_permission_prompt" comment="Message shown when contacts permission is required to manage favorites.">To manage favorites, turn on the contacts permissions</string>
+    <string name="your_info" comment="Label for the device owner's contact profile.">Your info</string>
+    <string name="share_contact" comment="Accessibility label for sharing a contact.">Share contact</string>
 </resources>

--- a/feature/contacts/src/test/java/dev/alenajam/opendialer/feature/contacts/ContactsViewModelTest.kt
+++ b/feature/contacts/src/test/java/dev/alenajam/opendialer/feature/contacts/ContactsViewModelTest.kt
@@ -97,6 +97,8 @@ private class FakeContactsRepository(contacts: List<DialerContactSummaryEntity>)
 
     override fun getContacts(): Flow<List<DialerContactSummaryEntity>> = contactsFlow
 
+    override fun getProfileContact(): Flow<DialerContactSummaryEntity?> = MutableStateFlow(null)
+
     override fun getFavoriteContacts(): Flow<List<DialerContactEntity>> = MutableStateFlow(emptyList())
 
     override suspend fun toggleFavorite(contactId: Int, isFavorite: Boolean) {


### PR DESCRIPTION
Adds a compact owner-profile card above favorites when Android exposes a named profile. It opens profile details and supports sharing the profile as a vCard.