### PR TITLE
style: compact expandable call cards

### DIFF
--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
@@ -518,7 +518,7 @@ private fun CallRow(
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(vertical = 16.dp, horizontal = 16.dp),
+                modifier = Modifier.padding(vertical = 12.dp, horizontal = 16.dp),
             ) {
                 ContactAvatar(
                     name = call.contactInfo.name.takeUnless { call.isVoicemailNumber },
@@ -700,7 +700,7 @@ private fun CallRowButton(
         Row(
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
         ) {
             Icon(
                 imageVector = icon,

--- a/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/ContactsSearchScreen.kt
+++ b/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/ContactsSearchScreen.kt
@@ -398,7 +398,7 @@ private fun ResultRow(
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(16.dp),
+                modifier = Modifier.padding(vertical = 12.dp, horizontal = 16.dp),
             ) {
                 ContactAvatar(
                     name = contact.name.takeIf { it.isNotBlank() },
@@ -501,7 +501,7 @@ private fun ResultActionRow(
         Row(
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
         ) {
             Icon(
                 imageVector = icon,


### PR DESCRIPTION
Reduces vertical padding in call-log, contact-search, and dialpad-search expandable cards to keep their layouts aligned.