### PR TITLE
docs: require focused pull requests

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -6,6 +6,10 @@
 - Do not call `LocalContext.current.getString()` or read `LocalContext.current.resources` from a composable. Use `stringResource`/`pluralStringResource`, or `LocalResources.current` when a resource must be resolved dynamically, so configuration changes invalidate the composition.
 - When translating UI labels, account for the available space: keep compact controls such as buttons and navigation labels as short as the target language allows, without sacrificing clarity.
 
+## Code organization
+
+- Keep screen files focused on UI composition and event wiring. Move reusable or non-UI helpers—such as matching, formatting, and data transformation—into appropriately named files.
+
 ## Git workflow
 
 - GitHub release changelog generation relies on merge commits. Make every change through a pull request and merge it into `main`; never commit directly to `main`.


### PR DESCRIPTION
Documents focused pull-request workflow and keeps screen files limited to UI composition and event wiring; reusable matching, formatting, and transformation helpers belong in dedicated files.