### PR TITLE
style: align dialpad search top spacing

### DIFF
--- a/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/ContactsSearchScreen.kt
+++ b/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/ContactsSearchScreen.kt
@@ -162,7 +162,7 @@ fun ContactsSearchScreen(
                 return@Surface
             }
 
-            Column {
+            Column(modifier = Modifier.padding(top = 8.dp)) {
                 SearchList(
                     result = result.value,
                     openRowKey = openRowKey,


### PR DESCRIPTION
Adds an 8dp top inset to dialpad search content, matching the call log's section spacing.