### PR TITLE
fix: resolve call log phone types

### DIFF
--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallDetailData.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallDetailData.kt
@@ -66,6 +66,7 @@ abstract class CallDetailData {
         fun getData(
             cursor: Cursor,
             voicemailNumbers: Set<String> = emptySet(),
+            contactPhoneTypes: ContactPhoneTypes = ContactPhoneTypes.Empty,
         ): List<DialerCallEntity> {
             val start = System.currentTimeMillis()
             val list = mutableListOf<DialerCallEntity>()
@@ -74,6 +75,7 @@ abstract class CallDetailData {
                 do {
                     val number = cursor.getString(cursor.getColumnIndexOrThrow(Calls.NUMBER))
                     val type = cursor.getInt(cursor.getColumnIndexOrThrow(Calls.TYPE))
+                    val phoneType = contactPhoneTypes.findForNumber(number)
                     list.add(
                         DialerCallEntity(
                             id = cursor.getInt(cursor.getColumnIndexOrThrow(Calls._ID)),
@@ -86,7 +88,8 @@ abstract class CallDetailData {
                             photoUri = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_PHOTO_URI))
                                 ?.takeIf { it.isNotBlank() },
                             countryIso = cursor.getString(cursor.getColumnIndexOrThrow(Calls.COUNTRY_ISO)),
-                            label = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_LABEL)),
+                            label = phoneType?.label
+                                ?: cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_LABEL)),
                             photoId = cursor.getLong(cursor.getColumnIndexOrThrow(Calls.CACHED_PHOTO_ID)),
                             geoDescription = cursor.getString(cursor.getColumnIndexOrThrow(Calls.GEOCODED_LOCATION)),
                             formattedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_FORMATTED_NUMBER)),
@@ -94,7 +97,8 @@ abstract class CallDetailData {
                             lookupUri = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_LOOKUP_URI)),
                             postDialDigits = cursor.getString(cursor.getColumnIndexOrThrow(Calls.POST_DIAL_DIGITS)),
                             matchedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_MATCHED_NUMBER)),
-                            numberType = cursor.getInt(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_TYPE)),
+                            numberType = phoneType?.type
+                                ?: cursor.getInt(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_TYPE)),
                             isVoicemailNumber = type == Calls.OUTGOING_TYPE && voicemailNumbers.any {
                                 PhoneNumberUtils.compare(number, it)
                             },

--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsData.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsData.kt
@@ -75,6 +75,7 @@ abstract class CallsData {
         fun getData(
             cursor: Cursor,
             voicemailNumbers: Set<String> = emptySet(),
+            contactPhoneTypes: ContactPhoneTypes = ContactPhoneTypes.Empty,
         ): List<DialerCallEntity> {
             val start = System.currentTimeMillis()
 
@@ -83,6 +84,7 @@ abstract class CallsData {
                 do {
                     val number = cursor.getString(cursor.getColumnIndexOrThrow(Calls.NUMBER))
                     val type = cursor.getInt(cursor.getColumnIndexOrThrow(Calls.TYPE))
+                    val phoneType = contactPhoneTypes.findForNumber(number)
                     list.add(
                         DialerCallEntity(
                             id = cursor.getInt(cursor.getColumnIndexOrThrow(Calls._ID)),
@@ -95,7 +97,8 @@ abstract class CallsData {
                             photoUri = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_PHOTO_URI))
                                 ?.takeIf { it.isNotBlank() },
                             countryIso = cursor.getString(cursor.getColumnIndexOrThrow(Calls.COUNTRY_ISO)),
-                            label = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_LABEL)),
+                            label = phoneType?.label
+                                ?: cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_LABEL)),
                             photoId = cursor.getLong(cursor.getColumnIndexOrThrow(Calls.CACHED_PHOTO_ID)),
                             geoDescription = cursor.getString(cursor.getColumnIndexOrThrow(Calls.GEOCODED_LOCATION)),
                             formattedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_FORMATTED_NUMBER)),
@@ -103,7 +106,8 @@ abstract class CallsData {
                             lookupUri = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_LOOKUP_URI)),
                             postDialDigits = cursor.getString(cursor.getColumnIndexOrThrow(Calls.POST_DIAL_DIGITS)),
                             matchedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_MATCHED_NUMBER)),
-                            numberType = cursor.getInt(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_TYPE)),
+                            numberType = phoneType?.type
+                                ?: cursor.getInt(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_TYPE)),
                             isVoicemailNumber = type == Calls.OUTGOING_TYPE && voicemailNumbers.any {
                                 PhoneNumberUtils.compare(number, it)
                             },

--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsRepositoryImpl.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsRepositoryImpl.kt
@@ -26,19 +26,23 @@ class CallsRepositoryImpl @Inject constructor(
     override fun getCalls(): Flow<List<DialerCallEntity>> =
         callbackFlow {
             val callsUri = CallsData.getUri(app)
+            fun getCallsData(): List<DialerCallEntity>? =
+                CallsData.getCursor(app.contentResolver, callsUri)?.use {
+                    CallsData.getData(
+                        cursor = it,
+                        voicemailNumbers = voicemailNumberProvider.getNumbers(),
+                        contactPhoneTypes = getContactPhoneTypes(app.contentResolver),
+                    )
+                }
             val observer = object : ContentObserver(null) {
                 override fun onChange(selfChange: Boolean) {
-                    CallsData.getCursor(app.contentResolver, callsUri)?.use {
-                        trySend(CallsData.getData(it, voicemailNumberProvider.getNumbers()))
-                    }
+                    getCallsData()?.let(::trySend)
                 }
             }
 
             app.contentResolver.registerContentObserver(callsUri, true, observer)
 
-            CallsData.getCursor(app.contentResolver, callsUri)?.use {
-                trySend(CallsData.getData(it, voicemailNumberProvider.getNumbers()))
-            }
+            getCallsData()?.let(::trySend)
 
             awaitClose {
                 app.contentResolver.unregisterContentObserver(observer)
@@ -50,7 +54,11 @@ class CallsRepositoryImpl @Inject constructor(
         ids: List<Int>
     ): Either<Failure, List<DialerCallEntity>> {
         val data = CallDetailData.getCursor(contentResolver, ids)?.use { cursor ->
-            CallDetailData.getData(cursor, voicemailNumberProvider.getNumbers())
+            CallDetailData.getData(
+                cursor = cursor,
+                voicemailNumbers = voicemailNumberProvider.getNumbers(),
+                contactPhoneTypes = getContactPhoneTypes(contentResolver),
+            )
         } ?: return Either.Left(Failure.NoData)
 
         return if (data.isEmpty()) {

--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/ContactPhoneTypeResolver.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/ContactPhoneTypeResolver.kt
@@ -1,0 +1,61 @@
+package dev.alenajam.opendialer.data.calls
+
+import android.content.ContentResolver
+import android.provider.ContactsContract.CommonDataKinds.Phone
+import android.telephony.PhoneNumberUtils
+
+data class ContactPhoneType(
+    val number: String,
+    val type: Int,
+    val label: String?,
+)
+
+class ContactPhoneTypes private constructor(
+    private val phones: List<ContactPhoneType>,
+) {
+    private val phonesByNormalizedNumber = phones
+        .mapNotNull { phone ->
+            PhoneNumberUtils.normalizeNumber(phone.number)
+                .takeIf(String::isNotEmpty)
+                ?.let { normalizedNumber -> normalizedNumber to phone }
+        }
+        .toMap()
+
+    fun findForNumber(number: String?): ContactPhoneType? {
+        if (number.isNullOrBlank()) return null
+
+        val normalizedNumber = PhoneNumberUtils.normalizeNumber(number)
+        return phonesByNormalizedNumber[normalizedNumber]
+            ?: phones.firstOrNull { phone -> PhoneNumberUtils.compare(number, phone.number) }
+    }
+
+    companion object {
+        val Empty = ContactPhoneTypes(emptyList())
+
+        fun from(phones: List<ContactPhoneType>) = ContactPhoneTypes(phones)
+    }
+}
+
+internal fun getContactPhoneTypes(contentResolver: ContentResolver): ContactPhoneTypes = try {
+    contentResolver.query(
+        Phone.CONTENT_URI,
+        arrayOf(Phone.NUMBER, Phone.TYPE, Phone.LABEL),
+        "${Phone.NUMBER} IS NOT NULL",
+        null,
+        "${Phone.IS_SUPER_PRIMARY} DESC, ${Phone.IS_PRIMARY} DESC",
+    )?.use { cursor ->
+        buildList {
+            while (cursor.moveToNext()) {
+                add(
+                    ContactPhoneType(
+                        number = cursor.getString(cursor.getColumnIndexOrThrow(Phone.NUMBER)),
+                        type = cursor.getInt(cursor.getColumnIndexOrThrow(Phone.TYPE)),
+                        label = cursor.getString(cursor.getColumnIndexOrThrow(Phone.LABEL)),
+                    )
+                )
+            }
+        }
+    }.orEmpty().let(ContactPhoneTypes::from)
+} catch (_: SecurityException) {
+    ContactPhoneTypes.Empty
+}


### PR DESCRIPTION
## Summary
- resolve phone labels and types from the Contacts provider
- use a normalized-number index for efficient call-log lookups
- retain Android number comparison as a fallback for alternate formats

## Verification
- ./gradlew :data:calls:testDebugUnitTest :data:calls:compileDebugKotlin :feature:calls:testDebugUnitTest :app:assembleDebug --console=plain