### PR TITLE
feat: disable controls during call transitions

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -14,3 +14,4 @@
 
 - GitHub release changelog generation relies on merge commits. Make every change through a pull request and merge it into `main`; never commit directly to `main`.
 - Keep each pull request focused on one topic.
+- Do not use the `codex/` prefix when creating branches.

--- a/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/CallButton.kt
+++ b/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/CallButton.kt
@@ -35,10 +35,11 @@ internal fun CallButton(
     icon: ImageVector,
     label: String,
     isActive: Boolean? = false,
+    enabled: Boolean = true,
     onClick: () -> Unit
 ) {
     val containerColor by animateColorAsState(
-        targetValue = if (isActive == true) {
+        targetValue = if (isActive == true && enabled) {
             MaterialTheme.colorScheme.primary
         } else {
             MaterialTheme.colorScheme.surfaceContainerLowest
@@ -47,7 +48,9 @@ internal fun CallButton(
         label = "Call control container"
     )
     val contentColor by animateColorAsState(
-        targetValue = if (isActive == true) {
+        targetValue = if (!enabled) {
+            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+        } else if (isActive == true) {
             MaterialTheme.colorScheme.onPrimary
         } else {
             MaterialTheme.colorScheme.onSurface
@@ -71,6 +74,7 @@ internal fun CallButton(
     ) {
         Surface(
             onClick = onClick,
+            enabled = enabled,
             modifier = Modifier
                 .width(72.dp)
                 .height(64.dp)
@@ -97,7 +101,12 @@ internal fun CallButton(
             modifier = Modifier.width(72.dp),
             textAlign = TextAlign.Center,
             maxLines = 1,
-            overflow = TextOverflow.Ellipsis
+            overflow = TextOverflow.Ellipsis,
+            color = if (enabled) {
+                MaterialTheme.colorScheme.onSurface
+            } else {
+                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+            },
         )
     }
 }

--- a/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/Footer.kt
+++ b/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/Footer.kt
@@ -62,6 +62,8 @@ fun InCallControls(
     canHold: Boolean = true,
     showAddCall: Boolean = true,
     canAddCall: Boolean = true,
+    controlsEnabled: Boolean = true,
+    canHangup: Boolean = true,
     onHangup: () -> Unit,
     onMute: () -> Unit,
     onSpeaker: () -> Unit,
@@ -137,13 +139,13 @@ fun InCallControls(
 
                     val moreActions = buildList {
                         if (showAddCall) {
-                            add(MoreAction(icons.addCall, stringResource(R.string.action_add_call), onAddCall, enabled = canAddCall))
+                            add(MoreAction(icons.addCall, stringResource(R.string.action_add_call), onAddCall, enabled = controlsEnabled && canAddCall))
                         }
-                        if (canHold) add(MoreAction(icons.pause, stringResource(R.string.action_hold), onHold, isHolding == true))
-                        if (canMerge) add(MoreAction(icons.merge, stringResource(R.string.conference_merge), onMerge))
-                        if (canSwap) add(MoreAction(icons.swapCalls, stringResource(R.string.conference_swap), onSwap))
+                        if (canHold) add(MoreAction(icons.pause, stringResource(R.string.action_hold), onHold, isHolding == true, enabled = controlsEnabled))
+                        if (canMerge) add(MoreAction(icons.merge, stringResource(R.string.conference_merge), onMerge, enabled = controlsEnabled))
+                        if (canSwap) add(MoreAction(icons.swapCalls, stringResource(R.string.conference_swap), onSwap, enabled = controlsEnabled))
                         if (canManageConference) {
-                            add(MoreAction(icons.more, stringResource(R.string.conference_manage), onManageConference))
+                            add(MoreAction(icons.more, stringResource(R.string.conference_manage), onManageConference, enabled = controlsEnabled))
                         }
                     }
 
@@ -221,6 +223,7 @@ fun InCallControls(
                     icon = icons.dialpad,
                     label = stringResource(R.string.control_dialpad),
                     isActive = openSection.value == OpenSection.DIALPAD,
+                    enabled = controlsEnabled,
                     onClick = { toggleSectionButton(OpenSection.DIALPAD) }
                 )
 
@@ -228,6 +231,7 @@ fun InCallControls(
                     icon = icons.mute,
                     label = stringResource(R.string.control_mute),
                     isActive = isMuted,
+                    enabled = controlsEnabled,
                     onClick = onMute
                 )
 
@@ -236,6 +240,7 @@ fun InCallControls(
                         icon = icons.speaker,
                         label = currentAudioRoute?.label ?: stringResource(R.string.control_speaker),
                         isActive = isSpeaker == true || hasExternalAudioRoute,
+                        enabled = controlsEnabled,
                         onClick = {
                             if (hasExternalAudioRoute) audioRoutesExpanded.value = true else onSpeaker()
                         }
@@ -260,12 +265,14 @@ fun InCallControls(
                     icon = icons.more,
                     label = stringResource(R.string.control_more),
                     isActive = openSection.value == OpenSection.ADDITIONAL_ACTIONS,
+                    enabled = controlsEnabled,
                     onClick = { toggleSectionButton(OpenSection.ADDITIONAL_ACTIONS) }
                 )
             }
 
             Surface(
                 onClick = onHangup,
+                enabled = canHangup,
                 color = MaterialTheme.colorScheme.error,
                 shape = RoundedCornerShape(32.dp),
                 modifier = Modifier

--- a/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/InCallScreen.kt
+++ b/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/InCallScreen.kt
@@ -117,6 +117,11 @@ internal fun InCallScreen(
                     canHold = canHold,
                     showAddCall = !hasSecondaryCall,
                     canAddCall = canAddCall,
+                    controlsEnabled = uiState.status != CallStatus.CONNECTING &&
+                        uiState.status != CallStatus.DISCONNECTING &&
+                        uiState.status != CallStatus.DISCONNECTED,
+                    canHangup = uiState.status != CallStatus.DISCONNECTING &&
+                        uiState.status != CallStatus.DISCONNECTED,
                     onHangup = viewModel::hangup,
                     onMute = viewModel::turnMute,
                     onSpeaker = viewModel::turnSpeaker,


### PR DESCRIPTION
## Summary
- disable secondary in-call controls while connecting or closing a call
- keep dialing interactive and keep end-call available until disconnection begins
- preserve readable labels for active and disabled controls

## Verification
- ./gradlew :feature:inCall:testDebugUnitTest :feature:inCall:compileDebugKotlin --console=plain
- ./gradlew :feature:inCall:testDebugUnitTest :app:assembleDebug --console=plain