### PR TITLE
fix: hide zero call durations

### DIFF
--- a/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/CallDetailScreen.kt
+++ b/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/CallDetailScreen.kt
@@ -418,11 +418,13 @@ private fun CallRow(
             }
         }
 
-        Text(
-            text = CommonUtils.getDurationTimeStringMinimal(call.duration * 1000),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+        if (call.duration > 0) {
+            Text(
+                text = CommonUtils.getDurationTimeStringMinimal(call.duration * 1000),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- hide the duration label for zero-duration call-detail entries

## Verification
- ./gradlew :feature:callDetail:compileDebugKotlin