### PR TITLE
fix: persist favorites expansion

### DIFF
--- a/core/common/src/main/java/dev/alenajam/opendialer/core/common/SharedPreferenceHelper.kt
+++ b/core/common/src/main/java/dev/alenajam/opendialer/core/common/SharedPreferenceHelper.kt
@@ -16,6 +16,7 @@ object SharedPreferenceHelper {
     const val KEY_SETTING_QUICK_RESPONSES = "quick_responses"
     const val KEY_SETTING_BLOCKED_NUMBERS = "blockedNumbers"
     const val KEY_SETTING_NOTIFICATION_SETTINGS = "notificationSettings"
+    private const val KEY_CALL_LOG_FAVORITES_EXPANDED = "call_log_favorites_expanded"
 
     enum class ThemeMode(val nightMode: Int) {
         LIGHT(AppCompatDelegate.MODE_NIGHT_NO),
@@ -86,5 +87,15 @@ object SharedPreferenceHelper {
             .putString(KEY_SETTING_THEME, themeMode.nightMode.toString())
             .apply()
         CommonUtils.setTheme(themeMode.nightMode)
+    }
+
+    fun isCallLogFavoritesExpanded(context: Context): Boolean =
+        getSharedPreferences(context).getBoolean(KEY_CALL_LOG_FAVORITES_EXPANDED, true)
+
+    fun setCallLogFavoritesExpanded(context: Context, expanded: Boolean) {
+        getSharedPreferences(context)
+            .edit()
+            .putBoolean(KEY_CALL_LOG_FAVORITES_EXPANDED, expanded)
+            .apply()
     }
 }

--- a/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/HomeScreen.kt
+++ b/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/HomeScreen.kt
@@ -166,7 +166,7 @@ internal fun HomeScreen(
                         onOpenHistory = onOpenHistory,
                         onOpenContacts = { currentTab = HomeTab.CONTACTS },
                         onAddFavorite = onAddFavorite,
-                        onEditNumberBeforeCall = onOpenDialpad
+                        onEditNumberBeforeCall = onOpenDialpad,
                     )
                     HomeTab.CONTACTS -> ContactsScreen(onOpenHistory = onOpenHistory)
                     HomeTab.VOICEMAIL -> VoicemailScreen()

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallLogPreferences.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallLogPreferences.kt
@@ -1,0 +1,38 @@
+package dev.alenajam.opendialer.feature.calls
+
+import android.content.Context
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dev.alenajam.opendialer.core.common.SharedPreferenceHelper
+import javax.inject.Inject
+import javax.inject.Singleton
+
+interface CallLogPreferences {
+    fun isFavoritesExpanded(): Boolean
+
+    fun setFavoritesExpanded(expanded: Boolean)
+}
+
+class SharedPreferencesCallLogPreferences @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) : CallLogPreferences {
+    override fun isFavoritesExpanded(): Boolean =
+        SharedPreferenceHelper.isCallLogFavoritesExpanded(context)
+
+    override fun setFavoritesExpanded(expanded: Boolean) {
+        SharedPreferenceHelper.setCallLogFavoritesExpanded(context, expanded)
+    }
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CallLogPreferencesModule {
+    @Binds
+    @Singleton
+    abstract fun bindCallLogPreferences(
+        preferences: SharedPreferencesCallLogPreferences,
+    ): CallLogPreferences
+}

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
@@ -101,7 +101,7 @@ fun CallsScreen(
     onOpenHistory: (callIds: List<Int>) -> Unit,
     onOpenContacts: () -> Unit = {},
     onAddFavorite: () -> Unit = {},
-    onEditNumberBeforeCall: (String) -> Unit = {}
+    onEditNumberBeforeCall: (String) -> Unit = {},
 ) {
     val requestPermissions =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
@@ -145,9 +145,9 @@ fun CallsScreen(
 
     val calls = viewModel.calls.collectAsStateWithLifecycle()
     val favorites = viewModel.favorites.collectAsStateWithLifecycle()
+    val favoritesExpanded by viewModel.favoritesExpanded.collectAsStateWithLifecycle()
     val hasPermission = viewModel.hasRuntimePermission.collectAsStateWithLifecycle()
     var openRowId by remember { mutableStateOf<Int?>(null) }
-    var favoritesExpanded by remember { mutableStateOf(true) }
     var selectedFilter by remember { mutableStateOf(CallFilter.ALL) }
 
     val icons = LocalAppIcons.current
@@ -234,7 +234,7 @@ fun CallsScreen(
                     FavoritesSection(
                         favorites = favorites.value,
                         expanded = favoritesExpanded,
-                        onToggleExpand = { favoritesExpanded = !favoritesExpanded },
+                        onToggleExpand = viewModel::toggleFavoritesExpanded,
                         onAddClick = onAddFavorite,
                         onViewContactsClick = onOpenContacts,
                         onFavoriteClick = { placeCall(it.number) },

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsViewModel.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsViewModel.kt
@@ -30,11 +30,14 @@ class CallsViewModel
     private val app: Application,
     private val cacheRepository: CacheRepository,
     private val callPlacementRepository: CallPlacementRepository,
+    private val callLogPreferences: CallLogPreferences,
 ) : ViewModel() {
     private val _calls = MutableStateFlow<List<DialerCall>>(emptyList())
     val calls: StateFlow<List<DialerCall>> = _calls
     private val _favorites = MutableStateFlow<List<DialerContact>>(emptyList())
     val favorites: StateFlow<List<DialerContact>> = _favorites.asStateFlow()
+    private val _favoritesExpanded = MutableStateFlow(callLogPreferences.isFavoritesExpanded())
+    val favoritesExpanded: StateFlow<Boolean> = _favoritesExpanded.asStateFlow()
     private val _hasRuntimePermission = MutableStateFlow(false)
     val hasRuntimePermission: StateFlow<Boolean> = _hasRuntimePermission
     private var hasContactsRuntimePermission = false
@@ -110,6 +113,11 @@ class CallsViewModel
         viewModelScope.launch {
             contactsRepository.toggleFavorite(contactId, false)
         }
+    }
+
+    fun toggleFavoritesExpanded() {
+        _favoritesExpanded.value = !_favoritesExpanded.value
+        callLogPreferences.setFavoritesExpanded(_favoritesExpanded.value)
     }
 
     fun startCache() {

--- a/feature/calls/src/test/java/dev/alenajam/opendialer/feature/calls/CallsViewModelTest.kt
+++ b/feature/calls/src/test/java/dev/alenajam/opendialer/feature/calls/CallsViewModelTest.kt
@@ -56,6 +56,7 @@ class CallsViewModelTest {
             app = PermissionGrantedApplication(),
             cacheRepository = cacheRepository,
             callPlacementRepository = FakeCallPlacementRepository(),
+            callLogPreferences = FakeCallLogPreferences(),
         )
         advanceUntilIdle()
         val invalidationsBeforeContactChange = cacheRepository.invalidations
@@ -129,6 +130,16 @@ private class FakeCallPlacementRepository : CallPlacementRepository {
 
     override fun placeVoicemailCall(account: CallAccount?): CallPlacementResult =
         CallPlacementResult.Placed
+}
+
+private class FakeCallLogPreferences : CallLogPreferences {
+    private var favoritesExpanded = true
+
+    override fun isFavoritesExpanded(): Boolean = favoritesExpanded
+
+    override fun setFavoritesExpanded(expanded: Boolean) {
+        favoritesExpanded = expanded
+    }
 }
 
 private class FakeContactsRepository : ContactsRepository {


### PR DESCRIPTION
## Summary
- retain the call-log Favorites section's expanded state across app restarts
- keep call-log state ownership out of HomeScreen

## Verification
- ./gradlew :feature:calls:testDebugUnitTest
- ./gradlew :feature:appShell:compileDebugKotlin