### PR TITLE
refactor: encapsulate ContentResolver and use data classes for entities

### DIFF
--- a/core/common/src/main/java/dev/alenajam/opendialer/core/common/SharedPreferenceHelper.kt
+++ b/core/common/src/main/java/dev/alenajam/opendialer/core/common/SharedPreferenceHelper.kt
@@ -16,6 +16,7 @@ object SharedPreferenceHelper {
     const val KEY_SETTING_QUICK_RESPONSES = "quick_responses"
     const val KEY_SETTING_BLOCKED_NUMBERS = "blockedNumbers"
     const val KEY_SETTING_NOTIFICATION_SETTINGS = "notificationSettings"
+    private const val KEY_CALL_LOG_FAVORITES_EXPANDED = "call_log_favorites_expanded"
 
     enum class ThemeMode(val nightMode: Int) {
         LIGHT(AppCompatDelegate.MODE_NIGHT_NO),
@@ -86,5 +87,15 @@ object SharedPreferenceHelper {
             .putString(KEY_SETTING_THEME, themeMode.nightMode.toString())
             .apply()
         CommonUtils.setTheme(themeMode.nightMode)
+    }
+
+    fun isCallLogFavoritesExpanded(context: Context): Boolean =
+        getSharedPreferences(context).getBoolean(KEY_CALL_LOG_FAVORITES_EXPANDED, true)
+
+    fun setCallLogFavoritesExpanded(context: Context, expanded: Boolean) {
+        getSharedPreferences(context)
+            .edit()
+            .putBoolean(KEY_CALL_LOG_FAVORITES_EXPANDED, expanded)
+            .apply()
     }
 }

--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/BlockedNumbersData.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/BlockedNumbersData.kt
@@ -1,0 +1,24 @@
+package dev.alenajam.opendialer.data.calls
+
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.provider.BlockedNumberContract
+
+object BlockedNumbersData {
+    fun insert(contentResolver: ContentResolver, number: String): Uri? {
+        val values = ContentValues().apply {
+            put(BlockedNumberContract.BlockedNumbers.COLUMN_ORIGINAL_NUMBER, number)
+        }
+        return contentResolver.insert(BlockedNumberContract.BlockedNumbers.CONTENT_URI, values)
+    }
+
+    fun unblock(context: Context, number: String): Int {
+        return BlockedNumberContract.unblock(context, number)
+    }
+
+    fun isBlocked(context: Context, number: String?): Boolean {
+        return BlockedNumberContract.isBlocked(context, number)
+    }
+}

--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallDetailData.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallDetailData.kt
@@ -7,40 +7,39 @@ import android.provider.CallLog.Calls
 import android.telephony.PhoneNumberUtils
 import android.util.Log
 
-abstract class CallDetailData {
-    companion object {
-        private val TAG = CallDetailData::class.simpleName
-        val URI: Uri = Calls.CONTENT_URI
-        private const val LIMIT = 1000
+object CallDetailData {
+    private val TAG = CallDetailData::class.simpleName
+    val URI: Uri = Calls.CONTENT_URI
+    private const val LIMIT = 1000
 
-        private val projection = arrayOf(
-            Calls._ID,
-            Calls.NUMBER,
-            Calls.CACHED_NORMALIZED_NUMBER,
-            Calls.CACHED_NAME,
-            Calls.DATE,
-            Calls.DURATION,
-            Calls.TYPE,
-            Calls.NEW,
-            Calls.CACHED_PHOTO_URI,
-            Calls.COUNTRY_ISO,
-            Calls.CACHED_NUMBER_LABEL,
-            Calls.CACHED_PHOTO_ID,
-            Calls.GEOCODED_LOCATION,
-            Calls.CACHED_FORMATTED_NUMBER,
-            Calls.CACHED_NORMALIZED_NUMBER,
-            Calls.CACHED_LOOKUP_URI,
-            Calls.POST_DIAL_DIGITS,
-            Calls.CACHED_MATCHED_NUMBER,
-            Calls.CACHED_NUMBER_TYPE
-        )
+    private val projection = arrayOf(
+        Calls._ID,
+        Calls.NUMBER,
+        Calls.CACHED_NORMALIZED_NUMBER,
+        Calls.CACHED_NAME,
+        Calls.DATE,
+        Calls.DURATION,
+        Calls.TYPE,
+        Calls.NEW,
+        Calls.CACHED_PHOTO_URI,
+        Calls.COUNTRY_ISO,
+        Calls.CACHED_NUMBER_LABEL,
+        Calls.CACHED_PHOTO_ID,
+        Calls.GEOCODED_LOCATION,
+        Calls.CACHED_FORMATTED_NUMBER,
+        Calls.CACHED_NORMALIZED_NUMBER,
+        Calls.CACHED_LOOKUP_URI,
+        Calls.POST_DIAL_DIGITS,
+        Calls.CACHED_MATCHED_NUMBER,
+        Calls.CACHED_NUMBER_TYPE
+    )
 
-        /** Filter out:
-         *  - Blocked calls
-         *  - Non-video Duo calls
-         */
-        private val where = { ids: List<Int> ->
-            """
+    /** Filter out:
+     *  - Blocked calls
+     *  - Non-video Duo calls
+     */
+    private val where = { ids: List<Int> ->
+        """
             ${Calls.TYPE} != ${Calls.BLOCKED_TYPE}
             AND (
                 ${Calls.PHONE_ACCOUNT_COMPONENT_NAME} IS NULL
@@ -49,67 +48,66 @@ abstract class CallDetailData {
             )
             AND ${Calls._ID} in (${ids.joinToString(",")})
         """
-        }
+    }
 
-        fun getCursor(contentResolver: ContentResolver, ids: List<Int>): Cursor? =
-            contentResolver.query(
-                URI
-                    .buildUpon()
-                    .appendQueryParameter(Calls.LIMIT_PARAM_KEY, LIMIT.toString())
-                    .build(),
-                projection,
-                where(ids),
-                null,
-                Calls.DEFAULT_SORT_ORDER
-            )
+    fun getCursor(contentResolver: ContentResolver, ids: List<Int>): Cursor? =
+        contentResolver.query(
+            URI
+                .buildUpon()
+                .appendQueryParameter(Calls.LIMIT_PARAM_KEY, LIMIT.toString())
+                .build(),
+            projection,
+            where(ids),
+            null,
+            Calls.DEFAULT_SORT_ORDER
+        )
 
-        fun getData(
-            cursor: Cursor,
-            voicemailNumbers: Set<String> = emptySet(),
-            contactPhoneTypes: ContactPhoneTypes = ContactPhoneTypes.Empty,
-        ): List<DialerCallEntity> {
-            val start = System.currentTimeMillis()
-            val list = mutableListOf<DialerCallEntity>()
+    fun getData(
+        cursor: Cursor,
+        voicemailNumbers: Set<String> = emptySet(),
+        contactPhoneTypes: ContactPhoneTypes = ContactPhoneTypes.Empty,
+    ): List<DialerCallEntity> {
+        val start = System.currentTimeMillis()
+        val list = mutableListOf<DialerCallEntity>()
 
-            if (cursor.moveToFirst()) {
-                do {
-                    val number = cursor.getString(cursor.getColumnIndexOrThrow(Calls.NUMBER))
-                    val type = cursor.getInt(cursor.getColumnIndexOrThrow(Calls.TYPE))
-                    val phoneType = contactPhoneTypes.findForNumber(number)
-                    list.add(
-                        DialerCallEntity(
-                            id = cursor.getInt(cursor.getColumnIndexOrThrow(Calls._ID)),
-                            number = number,
-                            name = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NAME)),
-                            date = cursor.getLong(cursor.getColumnIndexOrThrow(Calls.DATE)),
-                            duration = cursor.getLong(cursor.getColumnIndexOrThrow(Calls.DURATION)),
-                            type = type,
-                            isNew = cursor.getInt(cursor.getColumnIndexOrThrow(Calls.NEW)),
-                            photoUri = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_PHOTO_URI))
-                                ?.takeIf { it.isNotBlank() },
-                            countryIso = cursor.getString(cursor.getColumnIndexOrThrow(Calls.COUNTRY_ISO)),
-                            label = phoneType?.label
-                                ?: cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_LABEL)),
-                            photoId = cursor.getLong(cursor.getColumnIndexOrThrow(Calls.CACHED_PHOTO_ID)),
-                            geoDescription = cursor.getString(cursor.getColumnIndexOrThrow(Calls.GEOCODED_LOCATION)),
-                            formattedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_FORMATTED_NUMBER)),
-                            normalizedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NORMALIZED_NUMBER)),
-                            lookupUri = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_LOOKUP_URI)),
-                            postDialDigits = cursor.getString(cursor.getColumnIndexOrThrow(Calls.POST_DIAL_DIGITS)),
-                            matchedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_MATCHED_NUMBER)),
-                            numberType = phoneType?.type
-                                ?: cursor.getInt(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_TYPE)),
-                            isVoicemailNumber = type == Calls.OUTGOING_TYPE && voicemailNumbers.any {
-                                PhoneNumberUtils.compare(number, it)
-                            },
-                        )
+        if (cursor.moveToFirst()) {
+            do {
+                val number = cursor.getString(cursor.getColumnIndexOrThrow(Calls.NUMBER))
+                val type = cursor.getInt(cursor.getColumnIndexOrThrow(Calls.TYPE))
+                val phoneType = contactPhoneTypes.findForNumber(number)
+                list.add(
+                    DialerCallEntity(
+                        id = cursor.getInt(cursor.getColumnIndexOrThrow(Calls._ID)),
+                        number = number,
+                        name = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NAME)),
+                        date = cursor.getLong(cursor.getColumnIndexOrThrow(Calls.DATE)),
+                        duration = cursor.getLong(cursor.getColumnIndexOrThrow(Calls.DURATION)),
+                        type = type,
+                        isNew = cursor.getInt(cursor.getColumnIndexOrThrow(Calls.NEW)),
+                        photoUri = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_PHOTO_URI))
+                            ?.takeIf { it.isNotBlank() },
+                        countryIso = cursor.getString(cursor.getColumnIndexOrThrow(Calls.COUNTRY_ISO)),
+                        label = phoneType?.label
+                            ?: cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_LABEL)),
+                        photoId = cursor.getLong(cursor.getColumnIndexOrThrow(Calls.CACHED_PHOTO_ID)),
+                        geoDescription = cursor.getString(cursor.getColumnIndexOrThrow(Calls.GEOCODED_LOCATION)),
+                        formattedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_FORMATTED_NUMBER)),
+                        normalizedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NORMALIZED_NUMBER)),
+                        lookupUri = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_LOOKUP_URI)),
+                        postDialDigits = cursor.getString(cursor.getColumnIndexOrThrow(Calls.POST_DIAL_DIGITS)),
+                        matchedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_MATCHED_NUMBER)),
+                        numberType = phoneType?.type
+                            ?: cursor.getInt(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_TYPE)),
+                        isVoicemailNumber = type == Calls.OUTGOING_TYPE && voicemailNumbers.any {
+                            PhoneNumberUtils.compare(number, it)
+                        },
                     )
-                } while (cursor.moveToNext())
-            }
-
-            val time = (System.currentTimeMillis() - start) / 1000f
-            Log.d(TAG, "Call log query time: $time seconds")
-            return list
+                )
+            } while (cursor.moveToNext())
         }
+
+        val time = (System.currentTimeMillis() - start) / 1000f
+        Log.d(TAG, "Call log query time: $time seconds")
+        return list
     }
 }

--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsData.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsData.kt
@@ -10,49 +10,50 @@ import android.provider.CallLog.Calls
 import android.telephony.PhoneNumberUtils
 import android.util.Log
 
-abstract class CallsData {
-    companion object {
-        private val TAG = CallsData::class.simpleName
-        /**
-         * Includes carrier-provided visual voicemail when the app holds the default dialer
-         * voicemail role. Other installations continue to read the regular call log.
-         */
-        fun getUri(context: Context): Uri = if (
-            context.checkSelfPermission(Manifest.permission.READ_VOICEMAIL) == PackageManager.PERMISSION_GRANTED
-        ) {
-            Calls.CONTENT_URI_WITH_VOICEMAIL
-        } else {
-            Calls.CONTENT_URI
-        }
-        private const val LIMIT = 1000
+object CallsData {
+    private val TAG = CallsData::class.simpleName
 
-        private val projection = arrayOf(
-            Calls._ID,
-            Calls.NUMBER,
-            Calls.CACHED_NORMALIZED_NUMBER,
-            Calls.CACHED_NAME,
-            Calls.DATE,
-            Calls.DURATION,
-            Calls.TYPE,
-            Calls.NEW,
-            Calls.CACHED_PHOTO_URI,
-            Calls.COUNTRY_ISO,
-            Calls.CACHED_NUMBER_LABEL,
-            Calls.CACHED_PHOTO_ID,
-            Calls.GEOCODED_LOCATION,
-            Calls.CACHED_FORMATTED_NUMBER,
-            Calls.CACHED_NORMALIZED_NUMBER,
-            Calls.CACHED_LOOKUP_URI,
-            Calls.POST_DIAL_DIGITS,
-            Calls.CACHED_MATCHED_NUMBER,
-            Calls.CACHED_NUMBER_TYPE
-        )
+    /**
+     * Includes carrier-provided visual voicemail when the app holds the default dialer
+     * voicemail role. Other installations continue to read the regular call log.
+     */
+    fun getUri(context: Context): Uri = if (
+        context.checkSelfPermission(Manifest.permission.READ_VOICEMAIL) == PackageManager.PERMISSION_GRANTED
+    ) {
+        Calls.CONTENT_URI_WITH_VOICEMAIL
+    } else {
+        Calls.CONTENT_URI
+    }
 
-        /** Filter out:
-         *  - Blocked calls
-         *  - Non-video Duo calls
-         */
-        private const val where = """
+    private const val LIMIT = 1000
+
+    private val projection = arrayOf(
+        Calls._ID,
+        Calls.NUMBER,
+        Calls.CACHED_NORMALIZED_NUMBER,
+        Calls.CACHED_NAME,
+        Calls.DATE,
+        Calls.DURATION,
+        Calls.TYPE,
+        Calls.NEW,
+        Calls.CACHED_PHOTO_URI,
+        Calls.COUNTRY_ISO,
+        Calls.CACHED_NUMBER_LABEL,
+        Calls.CACHED_PHOTO_ID,
+        Calls.GEOCODED_LOCATION,
+        Calls.CACHED_FORMATTED_NUMBER,
+        Calls.CACHED_NORMALIZED_NUMBER,
+        Calls.CACHED_LOOKUP_URI,
+        Calls.POST_DIAL_DIGITS,
+        Calls.CACHED_MATCHED_NUMBER,
+        Calls.CACHED_NUMBER_TYPE
+    )
+
+    /** Filter out:
+     *  - Blocked calls
+     *  - Non-video Duo calls
+     */
+    private const val where = """
             ${Calls.TYPE} != ${Calls.BLOCKED_TYPE}
             AND (
                 ${Calls.PHONE_ACCOUNT_COMPONENT_NAME} IS NULL
@@ -61,64 +62,71 @@ abstract class CallsData {
             )
         """
 
-        fun getCursor(contentResolver: ContentResolver, uri: Uri): Cursor? = contentResolver.query(
-            uri
-                .buildUpon()
-                .appendQueryParameter(Calls.LIMIT_PARAM_KEY, LIMIT.toString())
-                .build(),
-            projection,
-            where,
-            null,
-            Calls.DEFAULT_SORT_ORDER
-        )
+    fun getCursor(contentResolver: ContentResolver, uri: Uri): Cursor? = contentResolver.query(
+        uri
+            .buildUpon()
+            .appendQueryParameter(Calls.LIMIT_PARAM_KEY, LIMIT.toString())
+            .build(),
+        projection,
+        where,
+        null,
+        Calls.DEFAULT_SORT_ORDER
+    )
 
-        fun getData(
-            cursor: Cursor,
-            voicemailNumbers: Set<String> = emptySet(),
-            contactPhoneTypes: ContactPhoneTypes = ContactPhoneTypes.Empty,
-        ): List<DialerCallEntity> {
-            val start = System.currentTimeMillis()
+    fun getData(
+        cursor: Cursor,
+        voicemailNumbers: Set<String> = emptySet(),
+        contactPhoneTypes: ContactPhoneTypes = ContactPhoneTypes.Empty,
+    ): List<DialerCallEntity> {
+        val start = System.currentTimeMillis()
 
-            val list = mutableListOf<DialerCallEntity>()
-            if (cursor.moveToFirst()) {
-                do {
-                    val number = cursor.getString(cursor.getColumnIndexOrThrow(Calls.NUMBER))
-                    val type = cursor.getInt(cursor.getColumnIndexOrThrow(Calls.TYPE))
-                    val phoneType = contactPhoneTypes.findForNumber(number)
-                    list.add(
-                        DialerCallEntity(
-                            id = cursor.getInt(cursor.getColumnIndexOrThrow(Calls._ID)),
-                            number = number,
-                            name = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NAME)),
-                            date = cursor.getLong(cursor.getColumnIndexOrThrow(Calls.DATE)),
-                            duration = cursor.getLong(cursor.getColumnIndexOrThrow(Calls.DURATION)),
-                            type = type,
-                            isNew = cursor.getInt(cursor.getColumnIndexOrThrow(Calls.NEW)),
-                            photoUri = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_PHOTO_URI))
-                                ?.takeIf { it.isNotBlank() },
-                            countryIso = cursor.getString(cursor.getColumnIndexOrThrow(Calls.COUNTRY_ISO)),
-                            label = phoneType?.label
-                                ?: cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_LABEL)),
-                            photoId = cursor.getLong(cursor.getColumnIndexOrThrow(Calls.CACHED_PHOTO_ID)),
-                            geoDescription = cursor.getString(cursor.getColumnIndexOrThrow(Calls.GEOCODED_LOCATION)),
-                            formattedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_FORMATTED_NUMBER)),
-                            normalizedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NORMALIZED_NUMBER)),
-                            lookupUri = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_LOOKUP_URI)),
-                            postDialDigits = cursor.getString(cursor.getColumnIndexOrThrow(Calls.POST_DIAL_DIGITS)),
-                            matchedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_MATCHED_NUMBER)),
-                            numberType = phoneType?.type
-                                ?: cursor.getInt(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_TYPE)),
-                            isVoicemailNumber = type == Calls.OUTGOING_TYPE && voicemailNumbers.any {
-                                PhoneNumberUtils.compare(number, it)
-                            },
-                        )
+        val list = mutableListOf<DialerCallEntity>()
+        if (cursor.moveToFirst()) {
+            do {
+                val number = cursor.getString(cursor.getColumnIndexOrThrow(Calls.NUMBER))
+                val type = cursor.getInt(cursor.getColumnIndexOrThrow(Calls.TYPE))
+                val phoneType = contactPhoneTypes.findForNumber(number)
+                list.add(
+                    DialerCallEntity(
+                        id = cursor.getInt(cursor.getColumnIndexOrThrow(Calls._ID)),
+                        number = number,
+                        name = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NAME)),
+                        date = cursor.getLong(cursor.getColumnIndexOrThrow(Calls.DATE)),
+                        duration = cursor.getLong(cursor.getColumnIndexOrThrow(Calls.DURATION)),
+                        type = type,
+                        isNew = cursor.getInt(cursor.getColumnIndexOrThrow(Calls.NEW)),
+                        photoUri = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_PHOTO_URI))
+                            ?.takeIf { it.isNotBlank() },
+                        countryIso = cursor.getString(cursor.getColumnIndexOrThrow(Calls.COUNTRY_ISO)),
+                        label = phoneType?.label
+                            ?: cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_LABEL)),
+                        photoId = cursor.getLong(cursor.getColumnIndexOrThrow(Calls.CACHED_PHOTO_ID)),
+                        geoDescription = cursor.getString(cursor.getColumnIndexOrThrow(Calls.GEOCODED_LOCATION)),
+                        formattedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_FORMATTED_NUMBER)),
+                        normalizedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_NORMALIZED_NUMBER)),
+                        lookupUri = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_LOOKUP_URI)),
+                        postDialDigits = cursor.getString(cursor.getColumnIndexOrThrow(Calls.POST_DIAL_DIGITS)),
+                        matchedNumber = cursor.getString(cursor.getColumnIndexOrThrow(Calls.CACHED_MATCHED_NUMBER)),
+                        numberType = phoneType?.type
+                            ?: cursor.getInt(cursor.getColumnIndexOrThrow(Calls.CACHED_NUMBER_TYPE)),
+                        isVoicemailNumber = type == Calls.OUTGOING_TYPE && voicemailNumbers.any {
+                            PhoneNumberUtils.compare(number, it)
+                        },
                     )
-                } while (cursor.moveToNext())
-            }
-
-            val time = (System.currentTimeMillis() - start) / 1000f
-            Log.d(TAG, "Call log query time: $time seconds")
-            return list
+                )
+            } while (cursor.moveToNext())
         }
+
+        val time = (System.currentTimeMillis() - start) / 1000f
+        Log.d(TAG, "Call log query time: $time seconds")
+        return list
+    }
+
+    fun delete(contentResolver: ContentResolver, id: Int): Int {
+        return contentResolver.delete(
+            Calls.CONTENT_URI,
+            "${Calls._ID} = ?",
+            arrayOf(id.toString())
+        )
     }
 }

--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsRepository.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsRepository.kt
@@ -1,6 +1,5 @@
 package dev.alenajam.opendialer.data.calls
 
-import android.content.ContentResolver
 import dev.alenajam.opendialer.core.common.exception.Failure
 import dev.alenajam.opendialer.core.common.functional.Either
 import kotlinx.coroutines.flow.Flow
@@ -8,7 +7,6 @@ import kotlinx.coroutines.flow.Flow
 interface CallsRepository {
     fun getCalls(): Flow<List<DialerCallEntity>>
     suspend fun getCallByIds(
-        contentResolver: ContentResolver,
         ids: List<Int>
     ): Either<Failure, List<DialerCallEntity>>
 

--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsRepositoryImpl.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsRepositoryImpl.kt
@@ -2,11 +2,8 @@ package dev.alenajam.opendialer.data.calls
 
 import android.app.Application
 import android.content.ContentResolver
-import android.content.ContentValues
 import android.database.ContentObserver
-import android.net.Uri
 import android.provider.BlockedNumberContract
-import android.provider.CallLog
 import dev.alenajam.opendialer.core.common.DefaultPhoneManager
 import dev.alenajam.opendialer.core.common.PermissionUtils
 import dev.alenajam.opendialer.core.common.exception.Failure
@@ -50,14 +47,13 @@ class CallsRepositoryImpl @Inject constructor(
         }
 
     override suspend fun getCallByIds(
-        contentResolver: ContentResolver,
         ids: List<Int>
     ): Either<Failure, List<DialerCallEntity>> {
-        val data = CallDetailData.getCursor(contentResolver, ids)?.use { cursor ->
+        val data = CallDetailData.getCursor(app.contentResolver, ids)?.use { cursor ->
             CallDetailData.getData(
                 cursor = cursor,
                 voicemailNumbers = voicemailNumberProvider.getNumbers(),
-                contactPhoneTypes = getContactPhoneTypes(contentResolver),
+                contactPhoneTypes = getContactPhoneTypes(app.contentResolver),
             )
         } ?: return Either.Left(Failure.NoData)
 
@@ -96,7 +92,7 @@ class CallsRepositoryImpl @Inject constructor(
                 val canUserBlockNumbers = BlockedNumberContract.canCurrentUserBlockNumbers(this)
                 if (hasDefault && canUserBlockNumbers) {
                     val isBlocked =
-                        BlockedNumberContract.isBlocked(this, call.contactInfo.number)
+                        BlockedNumbersData.isBlocked(this, call.contactInfo.number)
                     val blockOption = CallOption(
                         if (isBlocked) CallOption.ID_UNBLOCK_CALLER else CallOption.ID_BLOCK_CALLER,
                         0
@@ -116,27 +112,19 @@ class CallsRepositoryImpl @Inject constructor(
 
         var deleted = 0
         calls.forEach {
-            deleted += app.contentResolver.delete(
-                CallLog.Calls.CONTENT_URI,
-                "${CallLog.Calls._ID} = ${it.id}",
-                null
-            )
+            deleted += CallsData.delete(app.contentResolver, it.id)
         }
 
         return if (deleted > 0) Either.Right(Unit) else Either.Left(Failure.LocalFailure)
     }
 
     override suspend fun blockCaller(number: String): Either<Failure, Unit> {
-        val values = ContentValues().apply {
-            put(BlockedNumberContract.BlockedNumbers.COLUMN_ORIGINAL_NUMBER, number)
-        }
-        val uri: Uri? =
-            app.contentResolver.insert(BlockedNumberContract.BlockedNumbers.CONTENT_URI, values)
+        val uri = BlockedNumbersData.insert(app.contentResolver, number)
         return if (uri == null) Either.Left(Failure.LocalFailure) else Either.Right(Unit)
     }
 
     override suspend fun unblockCaller(number: String): Either<Failure, Unit> {
-        val blocked = BlockedNumberContract.unblock(app, number)
+        val blocked = BlockedNumbersData.unblock(app, number)
         return if (blocked < 1) Either.Left(Failure.LocalFailure) else Either.Right(Unit)
     }
 }

--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/ContactInfo.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/ContactInfo.kt
@@ -1,9 +1,8 @@
 package dev.alenajam.opendialer.data.calls
 
-import android.text.TextUtils
 import java.io.Serializable
 
-class ContactInfo(
+data class ContactInfo(
     val name: String? = null,
     val number: String? = null,
     val photoUri: String? = null,
@@ -17,63 +16,5 @@ class ContactInfo(
 ) : Serializable {
     companion object {
         val EMPTY = ContactInfo()
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) {
-            return true
-        }
-
-        if (other === null) {
-            return false
-        }
-
-        if (other !is ContactInfo) {
-            return false
-        }
-
-        if (!TextUtils.equals(lookupUri, other.lookupUri)) {
-            return false
-        }
-        if (!TextUtils.equals(name, other.name)) {
-            return false
-        }
-        if (type != other.type) {
-            return false
-        }
-        if (!TextUtils.equals(label, other.label)) {
-            return false
-        }
-        if (!TextUtils.equals(number, other.number)) {
-            return false
-        }
-        if (!TextUtils.equals(formattedNumber, other.formattedNumber)) {
-            return false
-        }
-        if (!TextUtils.equals(normalizedNumber, other.normalizedNumber)) {
-            return false
-        }
-        if (photoId != other.photoId) {
-            return false
-        }
-        if (!TextUtils.equals(photoUri, other.photoUri)) {
-            return false
-        }
-        if (!TextUtils.equals(geoDescription, other.geoDescription)) {
-            return false
-        }
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        // Uses only name and contactUri to determine hashcode.
-        // This should be sufficient to have a reasonable distribution of hash codes.
-        // Moreover, there should be no two people with the same lookupUri.
-        val prime = 31
-        var result = 1
-        result = prime * result + (lookupUri?.hashCode() ?: 0)
-        result = prime * result + (name?.hashCode() ?: 0)
-        return result
     }
 }

--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/DialerCallEntity.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/DialerCallEntity.kt
@@ -1,6 +1,6 @@
 package dev.alenajam.opendialer.data.calls
 
-class DialerCallEntity(
+data class DialerCallEntity(
     val id: Int,
     val number: String?,
     val name: String?,

--- a/data/callsCache/src/main/java/dev/alenajam/opendialer/data/callsCache/CacheData.kt
+++ b/data/callsCache/src/main/java/dev/alenajam/opendialer/data/callsCache/CacheData.kt
@@ -1,0 +1,84 @@
+package dev.alenajam.opendialer.data.callsCache
+
+import android.content.Context
+import android.provider.ContactsContract
+import android.telephony.PhoneNumberUtils
+import dev.alenajam.opendialer.core.aosp.UriUtils
+
+object CacheData {
+    fun getContactInfoByNumber(
+        context: Context,
+        number: String,
+        countryIso: String?
+    ): ContactInfo {
+        val uri = ContactsContract.PhoneLookup.CONTENT_FILTER_URI
+
+        val projection = arrayOf(
+            ContactsContract.PhoneLookup.CONTACT_ID,
+            ContactsContract.PhoneLookup.DISPLAY_NAME,
+            ContactsContract.PhoneLookup.TYPE,
+            ContactsContract.PhoneLookup.LABEL,
+            ContactsContract.PhoneLookup.NUMBER,
+            ContactsContract.PhoneLookup.NORMALIZED_NUMBER,
+            ContactsContract.PhoneLookup.PHOTO_ID,
+            ContactsContract.PhoneLookup.LOOKUP_KEY,
+            ContactsContract.PhoneLookup.PHOTO_URI
+        )
+
+        context.contentResolver.query(
+            uri
+                .buildUpon()
+                .appendPath(number)
+                .build(),
+            projection,
+            null,
+            null,
+            null
+        )?.use {
+            if (it.moveToFirst()) {
+                val lookupKey =
+                    it.getString(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.LOOKUP_KEY))
+                val contactId =
+                    it.getLong(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.CONTACT_ID))
+                return ContactInfo(
+                    name = it.getString(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.DISPLAY_NAME)),
+                    number = it.getString(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.NUMBER)),
+                    photoUri = it.getString(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.PHOTO_URI))
+                        ?.takeIf { uri -> uri.isNotBlank() },
+                    type = it.getInt(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.TYPE)),
+                    label = it.getString(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.LABEL)),
+                    lookupUri = UriUtils.uriToString(
+                        ContactsContract.Contacts.getLookupUri(
+                            contactId,
+                            lookupKey
+                        )
+                    ),
+                    normalizedNumber = it.getString(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.NORMALIZED_NUMBER)),
+                    photoId = it.getLong(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.PHOTO_ID))
+                )
+            }
+        }
+
+        return createEmptyContactInfoForNumber(context, number, countryIso)
+    }
+
+    private fun createEmptyContactInfoForNumber(
+        context: Context,
+        number: String,
+        countryIso: String?
+    ): ContactInfo {
+        val formattedNumber: String =
+            ContactInfoHelper(context).formatPhoneNumber(number, null, countryIso)
+        val normalizedNumber = PhoneNumberUtils.formatNumberToE164(number, countryIso)
+        return ContactInfo(
+            number = number,
+            lookupUri = UriUtils.uriToString(
+                ContactInfoHelper.createTemporaryContactUri(
+                    formattedNumber
+                )
+            ),
+            normalizedNumber = normalizedNumber,
+            formattedNumber = formattedNumber
+        )
+    }
+}

--- a/data/callsCache/src/main/java/dev/alenajam/opendialer/data/callsCache/CacheRepositoryImpl.kt
+++ b/data/callsCache/src/main/java/dev/alenajam/opendialer/data/callsCache/CacheRepositoryImpl.kt
@@ -1,10 +1,6 @@
 package dev.alenajam.opendialer.data.callsCache
 
 import android.app.Application
-import android.content.Context
-import android.provider.ContactsContract
-import android.telephony.PhoneNumberUtils
-import dev.alenajam.opendialer.core.aosp.UriUtils
 import dev.alenajam.opendialer.core.common.exception.Failure
 import dev.alenajam.opendialer.core.common.functional.Either
 import kotlinx.coroutines.CoroutineScope
@@ -52,7 +48,7 @@ class CacheRepositoryImpl
         }
 
         /** Fetch new contact info */
-        val info = getContactInfoByNumber(
+        val info = CacheData.getContactInfoByNumber(
             app,
             request.number,
             request.countryIso
@@ -99,80 +95,4 @@ class CacheRepositoryImpl
     override fun invalidate() {
         requestDeduplicator.clear()
     }
-}
-
-fun getContactInfoByNumber(
-    context: Context,
-    number: String,
-    countryIso: String?
-): ContactInfo {
-    val uri = ContactsContract.PhoneLookup.CONTENT_FILTER_URI
-
-    val projection = arrayOf(
-        ContactsContract.PhoneLookup.CONTACT_ID,
-        ContactsContract.PhoneLookup.DISPLAY_NAME,
-        ContactsContract.PhoneLookup.TYPE,
-        ContactsContract.PhoneLookup.LABEL,
-        ContactsContract.PhoneLookup.NUMBER,
-        ContactsContract.PhoneLookup.NORMALIZED_NUMBER,
-        ContactsContract.PhoneLookup.PHOTO_ID,
-        ContactsContract.PhoneLookup.LOOKUP_KEY,
-        ContactsContract.PhoneLookup.PHOTO_URI
-    )
-
-    context.contentResolver.query(
-        uri
-            .buildUpon()
-            .appendPath(number)
-            .build(),
-        projection,
-        null,
-        null,
-        null
-    )?.use {
-        if (it.moveToFirst()) {
-            val lookupKey =
-                it.getString(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.LOOKUP_KEY))
-            val contactId =
-                it.getLong(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.CONTACT_ID))
-            return ContactInfo(
-                name = it.getString(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.DISPLAY_NAME)),
-                number = it.getString(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.NUMBER)),
-                photoUri = it.getString(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.PHOTO_URI))
-                    ?.takeIf { uri -> uri.isNotBlank() },
-                type = it.getInt(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.TYPE)),
-                label = it.getString(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.LABEL)),
-                lookupUri = UriUtils.uriToString(
-                    ContactsContract.Contacts.getLookupUri(
-                        contactId,
-                        lookupKey
-                    )
-                ),
-                normalizedNumber = it.getString(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.NORMALIZED_NUMBER)),
-                photoId = it.getLong(it.getColumnIndexOrThrow(ContactsContract.PhoneLookup.PHOTO_ID))
-            )
-        }
-    }
-
-    return createEmptyContactInfoForNumber(context, number, countryIso)
-}
-
-private fun createEmptyContactInfoForNumber(
-    context: Context,
-    number: String,
-    countryIso: String?
-): ContactInfo {
-    val formattedNumber: String =
-        ContactInfoHelper(context).formatPhoneNumber(number, null, countryIso)
-    val normalizedNumber = PhoneNumberUtils.formatNumberToE164(number, countryIso)
-    return ContactInfo(
-        number = number,
-        lookupUri = UriUtils.uriToString(
-            ContactInfoHelper.createTemporaryContactUri(
-                formattedNumber
-            )
-        ),
-        normalizedNumber = normalizedNumber,
-        formattedNumber = formattedNumber
-    )
 }

--- a/data/callsCache/src/main/java/dev/alenajam/opendialer/data/callsCache/ContactInfo.kt
+++ b/data/callsCache/src/main/java/dev/alenajam/opendialer/data/callsCache/ContactInfo.kt
@@ -1,9 +1,8 @@
 package dev.alenajam.opendialer.data.callsCache
 
-import android.text.TextUtils
 import java.io.Serializable
 
-class ContactInfo(
+data class ContactInfo(
     val name: String? = null,
     val number: String? = null,
     val photoUri: String? = null,
@@ -17,63 +16,5 @@ class ContactInfo(
 ) : Serializable {
     companion object {
         val EMPTY = ContactInfo()
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) {
-            return true
-        }
-
-        if (other === null) {
-            return false
-        }
-
-        if (other !is ContactInfo) {
-            return false
-        }
-
-        if (!TextUtils.equals(lookupUri, other.lookupUri)) {
-            return false
-        }
-        if (!TextUtils.equals(name, other.name)) {
-            return false
-        }
-        if (type != other.type) {
-            return false
-        }
-        if (!TextUtils.equals(label, other.label)) {
-            return false
-        }
-        if (!TextUtils.equals(number, other.number)) {
-            return false
-        }
-        if (!TextUtils.equals(formattedNumber, other.formattedNumber)) {
-            return false
-        }
-        if (!TextUtils.equals(normalizedNumber, other.normalizedNumber)) {
-            return false
-        }
-        if (photoId != other.photoId) {
-            return false
-        }
-        if (!TextUtils.equals(photoUri, other.photoUri)) {
-            return false
-        }
-        if (!TextUtils.equals(geoDescription, other.geoDescription)) {
-            return false
-        }
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        // Uses only name and contactUri to determine hashcode.
-        // This should be sufficient to have a reasonable distribution of hash codes.
-        // Moreover, there should be no two people with the same lookupUri.
-        val prime = 31
-        var result = 1
-        result = prime * result + (lookupUri?.hashCode() ?: 0)
-        result = prime * result + (name?.hashCode() ?: 0)
-        return result
     }
 }

--- a/data/callsCache/src/main/java/dev/alenajam/opendialer/data/callsCache/ContactInfoRequest.kt
+++ b/data/callsCache/src/main/java/dev/alenajam/opendialer/data/callsCache/ContactInfoRequest.kt
@@ -1,7 +1,7 @@
 package dev.alenajam.opendialer.data.callsCache
 
-class ContactInfoRequest(
-    number: String?,
-    countryIso: String?,
+data class ContactInfoRequest(
+    val number: String?,
+    val countryIso: String?,
     val callLogInfo: ContactInfo
-) : NumberWithCountryIso(number, countryIso)
+)

--- a/data/callsCache/src/main/java/dev/alenajam/opendialer/data/callsCache/NumberWithCountryIso.kt
+++ b/data/callsCache/src/main/java/dev/alenajam/opendialer/data/callsCache/NumberWithCountryIso.kt
@@ -1,20 +1,6 @@
 package dev.alenajam.opendialer.data.callsCache
 
-open class NumberWithCountryIso(
+data class NumberWithCountryIso(
     val number: String?,
     val countryIso: String?
-) {
-    override fun equals(other: Any?): Boolean {
-        if (other == null) return false
-
-        if (other !is NumberWithCountryIso) return false
-
-        return number == other.number && countryIso == other.countryIso
-    }
-
-    override fun hashCode(): Int {
-        val numberHashCode = number?.hashCode() ?: 0
-        val countryIsoHashCode = countryIso?.hashCode() ?: 0
-        return numberHashCode.xor(countryIsoHashCode)
-    }
-}
+)

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsData.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsData.kt
@@ -1,54 +1,101 @@
 package dev.alenajam.opendialer.data.contacts
 
 import android.content.ContentResolver
+import android.content.ContentUris
+import android.content.ContentValues
 import android.database.Cursor
 import android.net.Uri
 import android.provider.ContactsContract
 
-abstract class ContactsData {
-    companion object {
-        val URI: Uri = ContactsContract.Contacts.CONTENT_URI
+object ContactsData {
+    val URI: Uri = ContactsContract.Contacts.CONTENT_URI
 
-        private val projection = arrayOf(
-            ContactsContract.Contacts._ID,
-            ContactsContract.Contacts.DISPLAY_NAME,
-            ContactsContract.Contacts.STARRED,
-            ContactsContract.Contacts.PHOTO_THUMBNAIL_URI,
+    private val projection = arrayOf(
+        ContactsContract.Contacts._ID,
+        ContactsContract.Contacts.DISPLAY_NAME,
+        ContactsContract.Contacts.STARRED,
+        ContactsContract.Contacts.PHOTO_THUMBNAIL_URI,
+    )
+
+    private const val where =
+        "${ContactsContract.Contacts.DISPLAY_NAME} IS NOT NULL"
+    private const val sort =
+        "${ContactsContract.Contacts.STARRED} DESC, ${ContactsContract.Contacts.SORT_KEY_PRIMARY}"
+
+    fun getCursor(contentResolver: ContentResolver): Cursor? = contentResolver.query(
+        URI,
+        projection,
+        where,
+        null,
+        sort
+    )
+
+    fun getNumbersCursor(contentResolver: ContentResolver, contactId: Int): Cursor? =
+        contentResolver.query(
+            ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
+            arrayOf(ContactsContract.CommonDataKinds.Phone.NUMBER),
+            "${ContactsContract.CommonDataKinds.Phone.CONTACT_ID} = ?",
+            arrayOf(contactId.toString()),
+            null
         )
 
-        private const val where =
-            "${ContactsContract.Contacts.DISPLAY_NAME} IS NOT NULL"
-        private const val sort =
-            "${ContactsContract.Contacts.STARRED} DESC, ${ContactsContract.Contacts.SORT_KEY_PRIMARY}"
-
-        fun getCursor(contentResolver: ContentResolver): Cursor? = contentResolver.query(
-            URI,
-            projection,
-            where,
-            null,
-            sort
-        )
-
-        fun getData(cursor: Cursor): List<DialerContactSummaryEntity> {
-            val list = mutableListOf<DialerContactSummaryEntity>()
-            if (cursor.moveToFirst()) {
-                do {
-                    list.add(
-                        DialerContactSummaryEntity(
-                            id = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.Contacts._ID)),
-                            name = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.Contacts.DISPLAY_NAME)),
-                            photoUri = cursor.getString(
-                                cursor.getColumnIndexOrThrow(
-                                    ContactsContract.Contacts.PHOTO_THUMBNAIL_URI
-                                )
-                            )
-                                ?.takeIf { it.isNotBlank() },
-                            starred = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.Contacts.STARRED)),
-                        )
-                    )
-                } while (cursor.moveToNext())
-            }
-            return list
+    fun getNumbersData(cursor: Cursor): List<String> {
+        val numbers = mutableListOf<String>()
+        while (cursor.moveToNext()) {
+            cursor.getString(0)?.takeIf { it.isNotBlank() }?.let(numbers::add)
         }
+        return numbers.distinct()
+    }
+
+    fun existsByIdCursor(contentResolver: ContentResolver, contactId: Int): Cursor? =
+        contentResolver.query(
+            ContentUris.withAppendedId(ContactsContract.Contacts.CONTENT_URI, contactId.toLong()),
+            arrayOf(ContactsContract.Contacts._ID),
+            null,
+            null,
+            null
+        )
+
+    fun existsByNumberCursor(contentResolver: ContentResolver, number: String): Cursor? =
+        contentResolver.query(
+            Uri.withAppendedPath(ContactsContract.PhoneLookup.CONTENT_FILTER_URI, Uri.encode(number)),
+            arrayOf(ContactsContract.PhoneLookup._ID),
+            null,
+            null,
+            null
+        )
+
+    fun getData(cursor: Cursor): List<DialerContactSummaryEntity> {
+        val list = mutableListOf<DialerContactSummaryEntity>()
+        if (cursor.moveToFirst()) {
+            do {
+                list.add(
+                    DialerContactSummaryEntity(
+                        id = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.Contacts._ID)),
+                        name = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.Contacts.DISPLAY_NAME)),
+                        photoUri = cursor.getString(
+                            cursor.getColumnIndexOrThrow(
+                                ContactsContract.Contacts.PHOTO_THUMBNAIL_URI
+                            )
+                        )
+                            ?.takeIf { it.isNotBlank() },
+                        starred = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.Contacts.STARRED)),
+                    )
+                )
+            } while (cursor.moveToNext())
+        }
+        return list
+    }
+
+    fun updateFavorite(contentResolver: ContentResolver, contactId: Int, isFavorite: Boolean): Int {
+        val values = ContentValues().apply {
+            put(ContactsContract.Contacts.STARRED, if (isFavorite) 1 else 0)
+        }
+        return contentResolver.update(
+            ContactsContract.Contacts.CONTENT_URI,
+            values,
+            "${ContactsContract.Contacts._ID} = ?",
+            arrayOf(contactId.toString())
+        )
     }
 }

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsRepository.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsRepository.kt
@@ -7,4 +7,6 @@ interface ContactsRepository {
     fun getProfileContact(): Flow<DialerContactSummaryEntity?>
     fun getFavoriteContacts(): Flow<List<DialerContactEntity>>
     suspend fun toggleFavorite(contactId: Int, isFavorite: Boolean)
+    suspend fun getContactNumbers(contactId: Int): List<String>
+    suspend fun contactExists(contactId: Int?, contactKeys: List<String>): Boolean
 }

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsRepositoryImpl.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package dev.alenajam.opendialer.data.contacts
 
 import android.app.Application
-import android.content.ContentValues
 import android.database.ContentObserver
 import android.provider.ContactsContract
 import kotlinx.coroutines.Dispatchers
@@ -62,15 +61,7 @@ class ContactsRepositoryImpl
         }
 
     override suspend fun toggleFavorite(contactId: Int, isFavorite: Boolean) {
-        val values = ContentValues().apply {
-            put(ContactsContract.Contacts.STARRED, if (isFavorite) 1 else 0)
-        }
-        app.contentResolver.update(
-            ContactsContract.Contacts.CONTENT_URI,
-            values,
-            "${ContactsContract.Contacts._ID} = ?",
-            arrayOf(contactId.toString())
-        )
+        ContactsData.updateFavorite(app.contentResolver, contactId, isFavorite)
     }
 
     override suspend fun getContactNumbers(contactId: Int): List<String> = withContext(Dispatchers.IO) {

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsRepositoryImpl.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ContactsRepositoryImpl.kt
@@ -4,10 +4,12 @@ import android.app.Application
 import android.content.ContentValues
 import android.database.ContentObserver
 import android.provider.ContactsContract
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class ContactsRepositoryImpl
@@ -69,5 +71,26 @@ class ContactsRepositoryImpl
             "${ContactsContract.Contacts._ID} = ?",
             arrayOf(contactId.toString())
         )
+    }
+
+    override suspend fun getContactNumbers(contactId: Int): List<String> = withContext(Dispatchers.IO) {
+        ContactsData.getNumbersCursor(app.contentResolver, contactId)?.use {
+            ContactsData.getNumbersData(it)
+        } ?: emptyList()
+    }
+
+    override suspend fun contactExists(
+        contactId: Int?,
+        contactKeys: List<String>
+    ): Boolean = withContext(Dispatchers.IO) {
+        try {
+            contactId?.let { id ->
+                ContactsData.existsByIdCursor(app.contentResolver, id)?.use { it.moveToFirst() } ?: false
+            } ?: contactKeys.any { number ->
+                ContactsData.existsByNumberCursor(app.contentResolver, number)?.use { it.moveToFirst() } == true
+            }
+        } catch (_: SecurityException) {
+            true
+        }
     }
 }

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/DialerContactEntity.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/DialerContactEntity.kt
@@ -1,6 +1,6 @@
 package dev.alenajam.opendialer.data.contacts
 
-class DialerContactEntity(
+data class DialerContactEntity(
     val dataId: Long,
     val id: Int,
     val name: String,

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/DialerContactSummaryEntity.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/DialerContactSummaryEntity.kt
@@ -1,6 +1,6 @@
 package dev.alenajam.opendialer.data.contacts
 
-class DialerContactSummaryEntity(
+data class DialerContactSummaryEntity(
     val id: Int,
     val name: String,
     val starred: Int,

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/FavoriteContactsData.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/FavoriteContactsData.kt
@@ -5,58 +5,56 @@ import android.database.Cursor
 import android.net.Uri
 import android.provider.ContactsContract
 
-abstract class FavoriteContactsData {
-    companion object {
-        val URI: Uri = ContactsContract.CommonDataKinds.Phone.CONTENT_URI
+object FavoriteContactsData {
+    val URI: Uri = ContactsContract.CommonDataKinds.Phone.CONTENT_URI
 
-        private val projection = arrayOf(
-            ContactsContract.CommonDataKinds.Phone._ID,
-            ContactsContract.CommonDataKinds.Phone.CONTACT_ID,
-            ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME,
-            ContactsContract.CommonDataKinds.Phone.STARRED,
-            ContactsContract.CommonDataKinds.Phone.PHOTO_THUMBNAIL_URI,
-            ContactsContract.CommonDataKinds.Phone.NUMBER,
-            ContactsContract.CommonDataKinds.Phone.TYPE,
-            ContactsContract.CommonDataKinds.Phone.LABEL,
-        )
+    private val projection = arrayOf(
+        ContactsContract.CommonDataKinds.Phone._ID,
+        ContactsContract.CommonDataKinds.Phone.CONTACT_ID,
+        ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME,
+        ContactsContract.CommonDataKinds.Phone.STARRED,
+        ContactsContract.CommonDataKinds.Phone.PHOTO_THUMBNAIL_URI,
+        ContactsContract.CommonDataKinds.Phone.NUMBER,
+        ContactsContract.CommonDataKinds.Phone.TYPE,
+        ContactsContract.CommonDataKinds.Phone.LABEL,
+    )
 
-        private const val where =
-            "${ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME} IS NOT NULL AND " +
-                "${ContactsContract.CommonDataKinds.Phone.NUMBER} IS NOT NULL AND " +
-                "${ContactsContract.CommonDataKinds.Phone.STARRED} = 1"
-        private const val sort =
-            "${ContactsContract.CommonDataKinds.Phone.SORT_KEY_PRIMARY}, " +
-                "${ContactsContract.CommonDataKinds.Phone.IS_SUPER_PRIMARY} DESC, " +
-                "${ContactsContract.CommonDataKinds.Phone.IS_PRIMARY} DESC"
+    private const val where =
+        "${ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME} IS NOT NULL AND " +
+            "${ContactsContract.CommonDataKinds.Phone.NUMBER} IS NOT NULL AND " +
+            "${ContactsContract.CommonDataKinds.Phone.STARRED} = 1"
+    private const val sort =
+        "${ContactsContract.CommonDataKinds.Phone.SORT_KEY_PRIMARY}, " +
+            "${ContactsContract.CommonDataKinds.Phone.IS_SUPER_PRIMARY} DESC, " +
+            "${ContactsContract.CommonDataKinds.Phone.IS_PRIMARY} DESC"
 
-        fun getCursor(contentResolver: ContentResolver): Cursor? = contentResolver.query(
-            URI,
-            projection,
-            where,
-            null,
-            sort,
-        )
+    fun getCursor(contentResolver: ContentResolver): Cursor? = contentResolver.query(
+        URI,
+        projection,
+        where,
+        null,
+        sort,
+    )
 
-        fun getData(cursor: Cursor): List<DialerContactEntity> {
-            val list = mutableListOf<DialerContactEntity>()
-            if (cursor.moveToFirst()) {
-                do {
-                    list.add(
-                        DialerContactEntity(
-                            dataId = cursor.getLong(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone._ID)),
-                            id = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.CONTACT_ID)),
-                            name = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME)),
-                            photoUri = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.PHOTO_THUMBNAIL_URI))
-                                ?.takeIf { it.isNotBlank() },
-                            starred = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.STARRED)),
-                            number = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER)),
-                            phoneType = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.TYPE)),
-                            phoneLabel = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.LABEL)),
-                        )
+    fun getData(cursor: Cursor): List<DialerContactEntity> {
+        val list = mutableListOf<DialerContactEntity>()
+        if (cursor.moveToFirst()) {
+            do {
+                list.add(
+                    DialerContactEntity(
+                        dataId = cursor.getLong(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone._ID)),
+                        id = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.CONTACT_ID)),
+                        name = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME)),
+                        photoUri = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.PHOTO_THUMBNAIL_URI))
+                            ?.takeIf { it.isNotBlank() },
+                        starred = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.STARRED)),
+                        number = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER)),
+                        phoneType = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.TYPE)),
+                        phoneLabel = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.LABEL)),
                     )
-                } while (cursor.moveToNext())
-            }
-            return list
+                )
+            } while (cursor.moveToNext())
         }
+        return list
     }
 }

--- a/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ProfileContactData.kt
+++ b/data/contacts/src/main/java/dev/alenajam/opendialer/data/contacts/ProfileContactData.kt
@@ -5,41 +5,39 @@ import android.database.Cursor
 import android.net.Uri
 import android.provider.ContactsContract
 
-abstract class ProfileContactData {
-    companion object {
-        val URI: Uri = ContactsContract.Profile.CONTENT_URI
+object ProfileContactData {
+    val URI: Uri = ContactsContract.Profile.CONTENT_URI
 
-        private val projection = arrayOf(
-            ContactsContract.Contacts._ID,
-            ContactsContract.Contacts.DISPLAY_NAME,
-            ContactsContract.Contacts.PHOTO_THUMBNAIL_URI,
-        )
+    private val projection = arrayOf(
+        ContactsContract.Contacts._ID,
+        ContactsContract.Contacts.DISPLAY_NAME,
+        ContactsContract.Contacts.PHOTO_THUMBNAIL_URI,
+    )
 
-        fun getCursor(contentResolver: ContentResolver): Cursor? = contentResolver.query(
-            URI,
-            projection,
-            "${ContactsContract.Contacts.DISPLAY_NAME} IS NOT NULL",
-            null,
-            null,
-        )
+    fun getCursor(contentResolver: ContentResolver): Cursor? = contentResolver.query(
+        URI,
+        projection,
+        "${ContactsContract.Contacts.DISPLAY_NAME} IS NOT NULL",
+        null,
+        null,
+    )
 
-        fun getData(cursor: Cursor): List<DialerContactSummaryEntity> = buildList {
-            if (cursor.moveToFirst()) {
-                add(
-                    DialerContactSummaryEntity(
-                        id = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.Contacts._ID)),
-                        name = cursor.getString(
-                            cursor.getColumnIndexOrThrow(ContactsContract.Contacts.DISPLAY_NAME)
-                        ),
-                        starred = 0,
-                        photoUri = cursor.getString(
-                            cursor.getColumnIndexOrThrow(
-                                ContactsContract.Contacts.PHOTO_THUMBNAIL_URI
-                            )
-                        )?.takeIf { it.isNotBlank() },
-                    )
+    fun getData(cursor: Cursor): List<DialerContactSummaryEntity> = buildList {
+        if (cursor.moveToFirst()) {
+            add(
+                DialerContactSummaryEntity(
+                    id = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.Contacts._ID)),
+                    name = cursor.getString(
+                        cursor.getColumnIndexOrThrow(ContactsContract.Contacts.DISPLAY_NAME)
+                    ),
+                    starred = 0,
+                    photoUri = cursor.getString(
+                        cursor.getColumnIndexOrThrow(
+                            ContactsContract.Contacts.PHOTO_THUMBNAIL_URI
+                        )
+                    )?.takeIf { it.isNotBlank() },
                 )
-            }
+            )
         }
     }
 }

--- a/data/contactsSearch/src/main/java/dev/alenajam/opendialer/data/contactsSearch/DialerRepository.kt
+++ b/data/contactsSearch/src/main/java/dev/alenajam/opendialer/data/contactsSearch/DialerRepository.kt
@@ -1,17 +1,14 @@
 package dev.alenajam.opendialer.data.contactsSearch
 
-import android.content.ContentResolver
 import dev.alenajam.opendialer.core.common.exception.Failure
 import dev.alenajam.opendialer.core.common.functional.Either
 
 interface DialerRepository {
     suspend fun searchContacts(
-        contentResolver: ContentResolver,
         query: String
     ): Either<Failure, List<DialerSearchContactEntity>>
 
     suspend fun searchContactsDialpad(
-        contentResolver: ContentResolver,
         query: String
     ): Either<Failure, List<DialerSearchContactEntity>>
 }

--- a/data/contactsSearch/src/main/java/dev/alenajam/opendialer/data/contactsSearch/DialerRepositoryImpl.kt
+++ b/data/contactsSearch/src/main/java/dev/alenajam/opendialer/data/contactsSearch/DialerRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package dev.alenajam.opendialer.data.contactsSearch
 
 import android.app.Application
-import android.content.ContentResolver
 import dev.alenajam.opendialer.core.common.exception.Failure
 import dev.alenajam.opendialer.core.common.functional.Either
 import javax.inject.Inject
@@ -9,10 +8,9 @@ import javax.inject.Inject
 class DialerRepositoryImpl
 @Inject constructor(private val app: Application) : DialerRepository {
     override suspend fun searchContacts(
-        contentResolver: ContentResolver,
         query: String
     ): Either<Failure, List<DialerSearchContactEntity>> {
-        SearchContactsData.getCursor(contentResolver, query)?.use {
+        SearchContactsData.getCursor(app.contentResolver, query)?.use {
             val data = SearchContactsData.getData(it)
             return Either.Right(data)
         }
@@ -21,10 +19,9 @@ class DialerRepositoryImpl
     }
 
     override suspend fun searchContactsDialpad(
-        contentResolver: ContentResolver,
         query: String
     ): Either<Failure, List<DialerSearchContactEntity>> {
-        SearchContactsDialpadData.getCursor(contentResolver)?.use {
+        SearchContactsDialpadData.getCursor(app.contentResolver)?.use {
             val data = SearchContactsDialpadData.getData(app, it, query)
             return Either.Right(data)
         }

--- a/data/contactsSearch/src/main/java/dev/alenajam/opendialer/data/contactsSearch/DialerSearchContactEntity.kt
+++ b/data/contactsSearch/src/main/java/dev/alenajam/opendialer/data/contactsSearch/DialerSearchContactEntity.kt
@@ -1,6 +1,6 @@
 package dev.alenajam.opendialer.data.contactsSearch
 
-class DialerSearchContactEntity(
+data class DialerSearchContactEntity(
     val dataId: Long,
     val id: Int,
     val name: String,

--- a/data/contactsSearch/src/main/java/dev/alenajam/opendialer/data/contactsSearch/SearchContactsData.kt
+++ b/data/contactsSearch/src/main/java/dev/alenajam/opendialer/data/contactsSearch/SearchContactsData.kt
@@ -5,60 +5,58 @@ import android.database.Cursor
 import android.net.Uri
 import android.provider.ContactsContract
 
-abstract class SearchContactsData {
-    companion object {
-        private val URI: Uri = ContactsContract.CommonDataKinds.Phone.CONTENT_FILTER_URI
+object SearchContactsData {
+    private val URI: Uri = ContactsContract.CommonDataKinds.Phone.CONTENT_FILTER_URI
 
-        private val projection = arrayOf(
-            ContactsContract.CommonDataKinds.Phone._ID,
-            ContactsContract.CommonDataKinds.Phone.TYPE,
-            ContactsContract.CommonDataKinds.Phone.LABEL,
-            ContactsContract.CommonDataKinds.Phone.NUMBER,
-            ContactsContract.CommonDataKinds.Phone.CONTACT_ID,
-            ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME,
-            ContactsContract.CommonDataKinds.Phone.PHOTO_THUMBNAIL_URI
+    private val projection = arrayOf(
+        ContactsContract.CommonDataKinds.Phone._ID,
+        ContactsContract.CommonDataKinds.Phone.TYPE,
+        ContactsContract.CommonDataKinds.Phone.LABEL,
+        ContactsContract.CommonDataKinds.Phone.NUMBER,
+        ContactsContract.CommonDataKinds.Phone.CONTACT_ID,
+        ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME,
+        ContactsContract.CommonDataKinds.Phone.PHOTO_THUMBNAIL_URI
+    )
+
+    private const val where =
+        "${ContactsContract.CommonDataKinds.Phone.NUMBER} IS NOT NULL AND ${ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME} IS NOT NULL"
+
+    fun getCursor(contentResolver: ContentResolver, query: String): Cursor? =
+        contentResolver.query(
+            URI.buildUpon().appendPath(query).build(),
+            projection,
+            where,
+            null,
+            ContactsContract.CommonDataKinds.Phone.SORT_KEY_PRIMARY
         )
 
-        private const val where =
-            "${ContactsContract.CommonDataKinds.Phone.NUMBER} IS NOT NULL AND ${ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME} IS NOT NULL"
-
-        fun getCursor(contentResolver: ContentResolver, query: String): Cursor? =
-            contentResolver.query(
-                URI.buildUpon().appendPath(query).build(),
-                projection,
-                where,
-                null,
-                ContactsContract.CommonDataKinds.Phone.SORT_KEY_PRIMARY
-            )
-
-        fun getData(cursor: Cursor): List<DialerSearchContactEntity> {
-            val list = mutableListOf<DialerSearchContactEntity>()
-            if (cursor.moveToFirst()) {
-                do {
-                    list.add(
-                        DialerSearchContactEntity(
-                            dataId = cursor.getLong(
-                                cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone._ID)
-                            ),
-                            id = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.CONTACT_ID)),
-                            name = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME)),
-                            photoUri = cursor.getString(
-                                cursor.getColumnIndexOrThrow(
-                                    ContactsContract.CommonDataKinds.Phone.PHOTO_THUMBNAIL_URI
-                                )
+    fun getData(cursor: Cursor): List<DialerSearchContactEntity> {
+        val list = mutableListOf<DialerSearchContactEntity>()
+        if (cursor.moveToFirst()) {
+            do {
+                list.add(
+                    DialerSearchContactEntity(
+                        dataId = cursor.getLong(
+                            cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone._ID)
+                        ),
+                        id = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.CONTACT_ID)),
+                        name = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.DISPLAY_NAME)),
+                        photoUri = cursor.getString(
+                            cursor.getColumnIndexOrThrow(
+                                ContactsContract.CommonDataKinds.Phone.PHOTO_THUMBNAIL_URI
                             )
-                                ?.takeIf { it.isNotBlank() },
-                            phoneType = cursor.getInt(
-                                cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.TYPE)
-                            ),
-                            label = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.LABEL)),
-                            contactId = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.CONTACT_ID)),
-                            number = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER))
                         )
+                            ?.takeIf { it.isNotBlank() },
+                        phoneType = cursor.getInt(
+                            cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.TYPE)
+                        ),
+                        label = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.LABEL)),
+                        contactId = cursor.getInt(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.CONTACT_ID)),
+                        number = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER))
                     )
-                } while (cursor.moveToNext())
-            }
-            return list
+                )
+            } while (cursor.moveToNext())
         }
+        return list
     }
 }

--- a/data/contactsSearch/src/main/java/dev/alenajam/opendialer/data/contactsSearch/SearchContactsDialpadData.kt
+++ b/data/contactsSearch/src/main/java/dev/alenajam/opendialer/data/contactsSearch/SearchContactsDialpadData.kt
@@ -7,74 +7,72 @@ import android.net.Uri
 import android.provider.ContactsContract.CommonDataKinds.Phone
 import dev.alenajam.opendialer.core.aosp.SmartDialNameMatcher
 
-abstract class SearchContactsDialpadData {
-    companion object {
-        private val URI: Uri = Phone.CONTENT_URI
-        private const val MAX_ENTRIES = 20
+object SearchContactsDialpadData {
+    private val URI: Uri = Phone.CONTENT_URI
+    private const val MAX_ENTRIES = 20
 
-        private val projection = arrayOf(
-            Phone._ID,
-            Phone.TYPE,
-            Phone.LABEL,
-            Phone.NUMBER,
-            Phone.CONTACT_ID,
-            Phone.DISPLAY_NAME,
-            Phone.PHOTO_THUMBNAIL_URI,
-            Phone.IS_PRIMARY
-        )
+    private val projection = arrayOf(
+        Phone._ID,
+        Phone.TYPE,
+        Phone.LABEL,
+        Phone.NUMBER,
+        Phone.CONTACT_ID,
+        Phone.DISPLAY_NAME,
+        Phone.PHOTO_THUMBNAIL_URI,
+        Phone.IS_PRIMARY
+    )
 
-        private const val where =
-            "${Phone.NUMBER} IS NOT NULL AND ${Phone.DISPLAY_NAME} IS NOT NULL"
-        private const val sort = """
+    private const val where =
+        "${Phone.NUMBER} IS NOT NULL AND ${Phone.DISPLAY_NAME} IS NOT NULL"
+    private const val sort = """
             ${Phone.STARRED} DESC,
             ${Phone.IS_SUPER_PRIMARY} DESC,
             ${Phone.DISPLAY_NAME_PRIMARY},
             ${Phone.IS_PRIMARY} DESC
         """
 
-        fun getCursor(contentResolver: ContentResolver): Cursor? = contentResolver.query(
-            URI,
-            projection,
-            where,
-            null,
-            sort
-        )
+    fun getCursor(contentResolver: ContentResolver): Cursor? = contentResolver.query(
+        URI,
+        projection,
+        where,
+        null,
+        sort
+    )
 
-        fun getData(
-            context: Context,
-            cursor: Cursor,
-            query: String
-        ): List<DialerSearchContactEntity> {
-            val nameMatcher = SmartDialNameMatcher(query)
-            val list = mutableListOf<DialerSearchContactEntity>()
-            if (cursor.moveToFirst()) {
-                do {
-                    val name = cursor.getString(cursor.getColumnIndexOrThrow(Phone.DISPLAY_NAME))
-                    val number = cursor.getString(cursor.getColumnIndexOrThrow(Phone.NUMBER))
-                    val contactId = cursor.getLong(cursor.getColumnIndexOrThrow(Phone.CONTACT_ID))
+    fun getData(
+        context: Context,
+        cursor: Cursor,
+        query: String
+    ): List<DialerSearchContactEntity> {
+        val nameMatcher = SmartDialNameMatcher(query)
+        val list = mutableListOf<DialerSearchContactEntity>()
+        if (cursor.moveToFirst()) {
+            do {
+                val name = cursor.getString(cursor.getColumnIndexOrThrow(Phone.DISPLAY_NAME))
+                val number = cursor.getString(cursor.getColumnIndexOrThrow(Phone.NUMBER))
+                val contactId = cursor.getLong(cursor.getColumnIndexOrThrow(Phone.CONTACT_ID))
 
-                    val nameMatches = query.isBlank() || nameMatcher.matches(context, name)
-                    val numberMatches = query.isNotBlank() &&
-                            nameMatcher.matchesNumber(context, number, query) != null
+                val nameMatches = query.isBlank() || nameMatcher.matches(context, name)
+                val numberMatches = query.isNotBlank() &&
+                        nameMatcher.matchesNumber(context, number, query) != null
 
-                    if (nameMatches || numberMatches) {
-                        list.add(
-                            DialerSearchContactEntity(
-                                dataId = cursor.getLong(cursor.getColumnIndexOrThrow(Phone._ID)),
-                                id = cursor.getInt(cursor.getColumnIndexOrThrow(Phone.CONTACT_ID)),
-                                name = name,
-                                photoUri = cursor.getString(cursor.getColumnIndexOrThrow(Phone.PHOTO_THUMBNAIL_URI))
-                                    ?.takeIf { it.isNotBlank() },
-                                phoneType = cursor.getInt(cursor.getColumnIndexOrThrow(Phone.TYPE)),
-                                label = cursor.getString(cursor.getColumnIndexOrThrow(Phone.LABEL)),
-                                contactId = contactId.toInt(),
-                                number = number
-                            )
+                if (nameMatches || numberMatches) {
+                    list.add(
+                        DialerSearchContactEntity(
+                            dataId = cursor.getLong(cursor.getColumnIndexOrThrow(Phone._ID)),
+                            id = cursor.getInt(cursor.getColumnIndexOrThrow(Phone.CONTACT_ID)),
+                            name = name,
+                            photoUri = cursor.getString(cursor.getColumnIndexOrThrow(Phone.PHOTO_THUMBNAIL_URI))
+                                ?.takeIf { it.isNotBlank() },
+                            phoneType = cursor.getInt(cursor.getColumnIndexOrThrow(Phone.TYPE)),
+                            label = cursor.getString(cursor.getColumnIndexOrThrow(Phone.LABEL)),
+                            contactId = contactId.toInt(),
+                            number = number
                         )
-                    }
-                } while (cursor.moveToNext() && list.size < MAX_ENTRIES)
-            }
-            return list
+                    )
+                }
+            } while (cursor.moveToNext() && list.size < MAX_ENTRIES)
         }
+        return list
     }
 }

--- a/data/voicemail/src/main/java/dev/alenajam/opendialer/data/voicemail/VoicemailData.kt
+++ b/data/voicemail/src/main/java/dev/alenajam/opendialer/data/voicemail/VoicemailData.kt
@@ -2,11 +2,13 @@ package dev.alenajam.opendialer.data.voicemail
 
 import android.content.ContentResolver
 import android.content.ContentUris
+import android.content.ContentValues
 import android.database.Cursor
+import android.net.Uri
 import android.provider.BaseColumns
 import android.provider.VoicemailContract
 
-internal object VoicemailData {
+object VoicemailData {
     val uri = VoicemailContract.Voicemails.CONTENT_URI
 
     private val projection = arrayOf(
@@ -44,5 +46,17 @@ internal object VoicemailData {
                 )
             )
         }
+    }
+
+    fun markRead(contentResolver: ContentResolver, voicemailUri: Uri): Int {
+        val values = ContentValues().apply {
+            put(VoicemailContract.Voicemails.IS_READ, 1)
+        }
+        return contentResolver.update(
+            voicemailUri,
+            values,
+            null,
+            null
+        )
     }
 }

--- a/data/voicemail/src/main/java/dev/alenajam/opendialer/data/voicemail/VoicemailRepositoryImpl.kt
+++ b/data/voicemail/src/main/java/dev/alenajam/opendialer/data/voicemail/VoicemailRepositoryImpl.kt
@@ -2,7 +2,6 @@ package dev.alenajam.opendialer.data.voicemail
 
 import android.Manifest
 import android.app.Application
-import android.content.ContentValues
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.database.ContentObserver
@@ -61,12 +60,7 @@ class VoicemailRepositoryImpl @Inject constructor(
 
     override suspend fun markRead(voicemail: Voicemail) {
         try {
-            app.contentResolver.update(
-                voicemail.uri,
-                ContentValues().apply { put(VoicemailContract.Voicemails.IS_READ, 1) },
-                null,
-                null,
-            )
+            VoicemailData.markRead(app.contentResolver, voicemail.uri)
         } catch (_: SecurityException) {
             // The default-dialer role can be revoked while the screen is open.
         }

--- a/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/HomeScreen.kt
+++ b/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/HomeScreen.kt
@@ -166,7 +166,7 @@ internal fun HomeScreen(
                         onOpenHistory = onOpenHistory,
                         onOpenContacts = { currentTab = HomeTab.CONTACTS },
                         onAddFavorite = onAddFavorite,
-                        onEditNumberBeforeCall = onOpenDialpad
+                        onEditNumberBeforeCall = onOpenDialpad,
                     )
                     HomeTab.CONTACTS -> ContactsScreen(onOpenHistory = onOpenHistory)
                     HomeTab.VOICEMAIL -> VoicemailScreen()

--- a/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/DialerViewModel.kt
+++ b/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/DialerViewModel.kt
@@ -49,7 +49,7 @@ class DialerViewModel
 
     fun getCallByIds(ids: List<Int>) {
         viewModelScope.launch {
-            callsRepositoryImpl.getCallByIds(app.contentResolver, ids).fold(
+            callsRepositoryImpl.getCallByIds(ids).fold(
                 { /* TODO handle failure */ },
                 { call -> _call.postValue(DialerCall.mapList(call).first()) }
             )

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallLogPreferences.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallLogPreferences.kt
@@ -1,0 +1,38 @@
+package dev.alenajam.opendialer.feature.calls
+
+import android.content.Context
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dev.alenajam.opendialer.core.common.SharedPreferenceHelper
+import javax.inject.Inject
+import javax.inject.Singleton
+
+interface CallLogPreferences {
+    fun isFavoritesExpanded(): Boolean
+
+    fun setFavoritesExpanded(expanded: Boolean)
+}
+
+class SharedPreferencesCallLogPreferences @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) : CallLogPreferences {
+    override fun isFavoritesExpanded(): Boolean =
+        SharedPreferenceHelper.isCallLogFavoritesExpanded(context)
+
+    override fun setFavoritesExpanded(expanded: Boolean) {
+        SharedPreferenceHelper.setCallLogFavoritesExpanded(context, expanded)
+    }
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CallLogPreferencesModule {
+    @Binds
+    @Singleton
+    abstract fun bindCallLogPreferences(
+        preferences: SharedPreferencesCallLogPreferences,
+    ): CallLogPreferences
+}

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
@@ -101,7 +101,7 @@ fun CallsScreen(
     onOpenHistory: (callIds: List<Int>) -> Unit,
     onOpenContacts: () -> Unit = {},
     onAddFavorite: () -> Unit = {},
-    onEditNumberBeforeCall: (String) -> Unit = {}
+    onEditNumberBeforeCall: (String) -> Unit = {},
 ) {
     val requestPermissions =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
@@ -145,9 +145,9 @@ fun CallsScreen(
 
     val calls = viewModel.calls.collectAsStateWithLifecycle()
     val favorites = viewModel.favorites.collectAsStateWithLifecycle()
+    val favoritesExpanded by viewModel.favoritesExpanded.collectAsStateWithLifecycle()
     val hasPermission = viewModel.hasRuntimePermission.collectAsStateWithLifecycle()
     var openRowId by remember { mutableStateOf<Int?>(null) }
-    var favoritesExpanded by remember { mutableStateOf(true) }
     var selectedFilter by remember { mutableStateOf(CallFilter.ALL) }
 
     val icons = LocalAppIcons.current
@@ -234,7 +234,7 @@ fun CallsScreen(
                     FavoritesSection(
                         favorites = favorites.value,
                         expanded = favoritesExpanded,
-                        onToggleExpand = { favoritesExpanded = !favoritesExpanded },
+                        onToggleExpand = viewModel::toggleFavoritesExpanded,
                         onAddClick = onAddFavorite,
                         onViewContactsClick = onOpenContacts,
                         onFavoriteClick = { placeCall(it.number) },

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsViewModel.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsViewModel.kt
@@ -30,11 +30,14 @@ class CallsViewModel
     private val app: Application,
     private val cacheRepository: CacheRepository,
     private val callPlacementRepository: CallPlacementRepository,
+    private val callLogPreferences: CallLogPreferences,
 ) : ViewModel() {
     private val _calls = MutableStateFlow<List<DialerCall>>(emptyList())
     val calls: StateFlow<List<DialerCall>> = _calls
     private val _favorites = MutableStateFlow<List<DialerContact>>(emptyList())
     val favorites: StateFlow<List<DialerContact>> = _favorites.asStateFlow()
+    private val _favoritesExpanded = MutableStateFlow(callLogPreferences.isFavoritesExpanded())
+    val favoritesExpanded: StateFlow<Boolean> = _favoritesExpanded.asStateFlow()
     private val _hasRuntimePermission = MutableStateFlow(false)
     val hasRuntimePermission: StateFlow<Boolean> = _hasRuntimePermission
     private var hasContactsRuntimePermission = false
@@ -110,6 +113,11 @@ class CallsViewModel
         viewModelScope.launch {
             contactsRepository.toggleFavorite(contactId, false)
         }
+    }
+
+    fun toggleFavoritesExpanded() {
+        _favoritesExpanded.value = !_favoritesExpanded.value
+        callLogPreferences.setFavoritesExpanded(_favoritesExpanded.value)
     }
 
     fun startCache() {

--- a/feature/calls/src/test/java/dev/alenajam/opendialer/feature/calls/CallsViewModelTest.kt
+++ b/feature/calls/src/test/java/dev/alenajam/opendialer/feature/calls/CallsViewModelTest.kt
@@ -56,6 +56,7 @@ class CallsViewModelTest {
             app = PermissionGrantedApplication(),
             cacheRepository = cacheRepository,
             callPlacementRepository = FakeCallPlacementRepository(),
+            callLogPreferences = FakeCallLogPreferences(),
         )
         advanceUntilIdle()
         val invalidationsBeforeContactChange = cacheRepository.invalidations
@@ -129,6 +130,16 @@ private class FakeCallPlacementRepository : CallPlacementRepository {
 
     override fun placeVoicemailCall(account: CallAccount?): CallPlacementResult =
         CallPlacementResult.Placed
+}
+
+private class FakeCallLogPreferences : CallLogPreferences {
+    private var favoritesExpanded = true
+
+    override fun isFavoritesExpanded(): Boolean = favoritesExpanded
+
+    override fun setFavoritesExpanded(expanded: Boolean) {
+        favoritesExpanded = expanded
+    }
 }
 
 private class FakeContactsRepository : ContactsRepository {

--- a/feature/calls/src/test/java/dev/alenajam/opendialer/feature/calls/CallsViewModelTest.kt
+++ b/feature/calls/src/test/java/dev/alenajam/opendialer/feature/calls/CallsViewModelTest.kt
@@ -109,7 +109,6 @@ private class FakeCallsRepository(calls: List<DialerCallEntity>) : CallsReposito
     override fun getCalls(): Flow<List<DialerCallEntity>> = calls
 
     override suspend fun getCallByIds(
-        contentResolver: android.content.ContentResolver,
         ids: List<Int>,
     ): Either<Failure, List<DialerCallEntity>> = Either.Left(Failure.NoData)
 
@@ -152,6 +151,10 @@ private class FakeContactsRepository : ContactsRepository {
     override fun getFavoriteContacts(): Flow<List<DialerContactEntity>> = favoriteContacts
 
     override suspend fun toggleFavorite(contactId: Int, isFavorite: Boolean) = Unit
+
+    override suspend fun getContactNumbers(contactId: Int): List<String> = emptyList()
+
+    override suspend fun contactExists(contactId: Int?, contactKeys: List<String>): Boolean = false
 
     fun emit(contacts: List<DialerContactEntity>) {
         favoriteContacts.value = contacts

--- a/feature/contacts/src/test/java/dev/alenajam/opendialer/feature/contacts/ContactsViewModelTest.kt
+++ b/feature/contacts/src/test/java/dev/alenajam/opendialer/feature/contacts/ContactsViewModelTest.kt
@@ -105,6 +105,10 @@ private class FakeContactsRepository(contacts: List<DialerContactSummaryEntity>)
         toggledContactId = contactId
         toggledIsFavorite = isFavorite
     }
+
+    override suspend fun getContactNumbers(contactId: Int): List<String> = emptyList()
+
+    override suspend fun contactExists(contactId: Int?, contactKeys: List<String>): Boolean = false
 }
 
 private class FakeCallsRepository(calls: List<DialerCallEntity>) : CallsRepository {
@@ -113,7 +117,6 @@ private class FakeCallsRepository(calls: List<DialerCallEntity>) : CallsReposito
     override fun getCalls(): Flow<List<DialerCallEntity>> = callsFlow
 
     override suspend fun getCallByIds(
-        contentResolver: android.content.ContentResolver,
         ids: List<Int>,
     ): Either<Failure, List<DialerCallEntity>> = Either.Left(Failure.NoData)
 

--- a/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/SearchContacts.kt
+++ b/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/SearchContacts.kt
@@ -1,6 +1,5 @@
 package dev.alenajam.opendialer.feature.contactsSearch
 
-import android.content.ContentResolver
 import dev.alenajam.opendialer.core.common.exception.Failure
 import dev.alenajam.opendialer.core.common.functional.Either
 import dev.alenajam.opendialer.core.common.interactor.UseCase
@@ -8,11 +7,11 @@ import dev.alenajam.opendialer.data.contactsSearch.DialerRepositoryImpl
 import dev.alenajam.opendialer.data.contactsSearch.DialerSearchContactEntity
 import javax.inject.Inject
 
-class SearchContactsParams(val contentResolver: ContentResolver, val query: String)
+data class SearchContactsParams(val query: String)
 
 class SearchContacts
 @Inject constructor(private val dialerRepositoryImpl: DialerRepositoryImpl) :
     UseCase<SearchContactsParams, List<DialerSearchContactEntity>>() {
     override suspend fun run(params: SearchContactsParams): Either<Failure, List<DialerSearchContactEntity>> =
-        dialerRepositoryImpl.searchContacts(params.contentResolver, params.query)
+        dialerRepositoryImpl.searchContacts(params.query)
 }

--- a/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/SearchContactsDialpad.kt
+++ b/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/SearchContactsDialpad.kt
@@ -1,6 +1,5 @@
 package dev.alenajam.opendialer.feature.contactsSearch
 
-import android.content.ContentResolver
 import dev.alenajam.opendialer.core.common.exception.Failure
 import dev.alenajam.opendialer.core.common.functional.Either
 import dev.alenajam.opendialer.core.common.interactor.UseCase
@@ -8,11 +7,11 @@ import dev.alenajam.opendialer.data.contactsSearch.DialerRepositoryImpl
 import dev.alenajam.opendialer.data.contactsSearch.DialerSearchContactEntity
 import javax.inject.Inject
 
-class SearchContactsDialpadParams(val contentResolver: ContentResolver, val query: String)
+data class SearchContactsDialpadParams(val query: String)
 
 class SearchContactsDialpad
 @Inject constructor(private val dialerRepositoryImpl: DialerRepositoryImpl) :
     UseCase<SearchContactsDialpadParams, List<DialerSearchContactEntity>>() {
     override suspend fun run(params: SearchContactsDialpadParams): Either<Failure, List<DialerSearchContactEntity>> =
-        dialerRepositoryImpl.searchContactsDialpad(params.contentResolver, params.query)
+        dialerRepositoryImpl.searchContactsDialpad(params.query)
 }

--- a/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/SearchContactsViewModel.kt
+++ b/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/SearchContactsViewModel.kt
@@ -80,7 +80,7 @@ class SearchContactsViewModel
         if (!hasRuntimePermission.value) return
         searchContactsDialpadUseCase(
             viewModelScope,
-            SearchContactsDialpadParams(app.contentResolver, query)
+            SearchContactsDialpadParams(query)
         ) {
             it.fold({}) { res ->
                 handleResult(
@@ -96,7 +96,7 @@ class SearchContactsViewModel
         if (!hasRuntimePermission.value) return
         searchContactsUseCase(
             viewModelScope,
-            SearchContactsParams(app.contentResolver, query)
+            SearchContactsParams(query)
         ) {
             it.fold({}) { contacts -> handleResult(query, contacts, isDialpadSearch = false) }
         }


### PR DESCRIPTION
This PR standardizes the architecture for data handling in OpenDialer by:
1. Encapsulating all ContentResolver interactions (queries, inserts, updates, deletes) within standardized *Data objects.
2. Converting all data-helper classes to Kotlin objects.
3. Converting entities, parameters, and info classes to Kotlin data classes for consistency.
4. Preserving and integrating specialized contact lookup methods in ContactsData.
5. Simplifying repository and use case interfaces by removing redundant ContentResolver parameters.