### PR TITLE
fix: limit contact search highlighting to prefixes

### DIFF
--- a/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/SearchMatchHighlighter.kt
+++ b/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/SearchMatchHighlighter.kt
@@ -29,7 +29,7 @@ internal fun highlightSearchMatch(
     } else if (isPhoneNumber) {
         textPhoneMatchPositions(text, query)
     } else {
-        textMatchPositions(text, query)
+        textPrefixMatchPositions(text, query)
     }
 
     return buildAnnotatedString {
@@ -44,13 +44,16 @@ internal fun highlightSearchMatch(
     }
 }
 
-private fun textMatchPositions(text: String, query: String): List<SmartDialMatchPosition> = buildList {
-    var startIndex = 0
-    while (startIndex < text.length) {
-        val matchStart = text.indexOf(query, startIndex, ignoreCase = true)
+internal fun textPrefixMatchPositions(text: String, query: String): List<SmartDialMatchPosition> = buildList {
+    var searchStart = 0
+    while (searchStart < text.length) {
+        val matchStart = text.indexOf(query, searchStart, ignoreCase = true)
         if (matchStart < 0) break
-        add(SmartDialMatchPosition(matchStart, matchStart + query.length))
-        startIndex = matchStart + query.length
+        if (matchStart == 0 || text[matchStart - 1].isWhitespace()) {
+            add(SmartDialMatchPosition(matchStart, matchStart + query.length))
+            break
+        }
+        searchStart = matchStart + query.length
     }
 }
 

--- a/feature/contactsSearch/src/test/java/dev/alenajam/opendialer/feature/contactsSearch/ExampleUnitTest.kt
+++ b/feature/contactsSearch/src/test/java/dev/alenajam/opendialer/feature/contactsSearch/ExampleUnitTest.kt
@@ -1,16 +1,33 @@
 package dev.alenajam.opendialer.feature.contactsSearch
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
-/**
- * Example local unit test, which will execute on the development machine (host).
- *
- * See [testing documentation](http://d.android.com/tools/testing).
- */
-class ExampleUnitTest {
+class SearchMatchHighlighterTest {
     @Test
-    fun addition_isCorrect() {
-        assertEquals(4, 2 + 2)
+    fun `text search highlights only a name prefix`() {
+        val matches = textPrefixMatchPositions("haaahaaa", "h")
+
+        assertEquals(1, matches.size)
+        assertEquals(0, matches.single().start)
+        assertEquals(1, matches.single().end)
+    }
+
+    @Test
+    fun `text search highlights a later word prefix`() {
+        val matches = textPrefixMatchPositions("Ada Hopper", "ho")
+
+        assertEquals(1, matches.size)
+        assertEquals(4, matches.single().start)
+        assertEquals(6, matches.single().end)
+    }
+
+    @Test
+    fun `text search ignores an earlier match in the middle of a word`() {
+        val matches = textPrefixMatchPositions("Chad Harry", "h")
+
+        assertEquals(1, matches.size)
+        assertEquals(5, matches.single().start)
+        assertEquals(6, matches.single().end)
     }
 }


### PR DESCRIPTION
## Summary
- limit text contact-match highlighting to name and word prefixes
- add regression coverage for repeated and middle-of-word characters

## Testing
- ./gradlew :feature:contactsSearch:testDebugUnitTest