### PR TITLE
feat(settings): add update check preference

### DIFF
--- a/core/common/src/main/java/dev/alenajam/opendialer/core/common/SharedPreferenceHelper.kt
+++ b/core/common/src/main/java/dev/alenajam/opendialer/core/common/SharedPreferenceHelper.kt
@@ -16,6 +16,7 @@ object SharedPreferenceHelper {
     const val KEY_SETTING_QUICK_RESPONSES = "quick_responses"
     const val KEY_SETTING_BLOCKED_NUMBERS = "blockedNumbers"
     const val KEY_SETTING_NOTIFICATION_SETTINGS = "notificationSettings"
+    const val KEY_SETTING_UPDATE_CHECKS = "update_checks"
     private const val KEY_CALL_LOG_FAVORITES_EXPANDED = "call_log_favorites_expanded"
     private const val KEY_DISMISSED_UPDATE_VERSION = "dismissed_update_version"
     private const val KEY_UPDATE_LAST_CHECK_MILLIS = "update_last_check_millis"
@@ -101,6 +102,16 @@ object SharedPreferenceHelper {
         getSharedPreferences(context)
             .edit()
             .putBoolean(KEY_CALL_LOG_FAVORITES_EXPANDED, expanded)
+            .apply()
+    }
+
+    fun isUpdateCheckEnabled(context: Context): Boolean =
+        getSharedPreferences(context).getBoolean(KEY_SETTING_UPDATE_CHECKS, true)
+
+    fun setUpdateCheckEnabled(context: Context, enabled: Boolean) {
+        getSharedPreferences(context)
+            .edit()
+            .putBoolean(KEY_SETTING_UPDATE_CHECKS, enabled)
             .apply()
     }
 

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallLogPreferences.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallLogPreferences.kt
@@ -7,6 +7,10 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dev.alenajam.opendialer.core.common.SharedPreferenceHelper
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -30,6 +34,8 @@ interface CallLogPreferences {
     fun getCachedAvailableUpdate(): AppUpdate?
 
     fun setCachedAvailableUpdate(update: AppUpdate?)
+
+    fun observeUpdateCheckEnabled(): Flow<Boolean>
 }
 
 class SharedPreferencesCallLogPreferences @Inject constructor(
@@ -71,6 +77,18 @@ class SharedPreferencesCallLogPreferences @Inject constructor(
     override fun setCachedAvailableUpdate(update: AppUpdate?) {
         SharedPreferenceHelper.setAvailableUpdate(context, update?.version, update?.releaseUrl)
     }
+
+    override fun observeUpdateCheckEnabled(): Flow<Boolean> = callbackFlow {
+        val preferences = SharedPreferenceHelper.getSharedPreferences(context)
+        val listener = android.content.SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == SharedPreferenceHelper.KEY_SETTING_UPDATE_CHECKS) {
+                trySend(SharedPreferenceHelper.isUpdateCheckEnabled(context))
+            }
+        }
+        trySend(SharedPreferenceHelper.isUpdateCheckEnabled(context))
+        preferences.registerOnSharedPreferenceChangeListener(listener)
+        awaitClose { preferences.unregisterOnSharedPreferenceChangeListener(listener) }
+    }.distinctUntilChanged()
 }
 
 @Module

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsViewModel.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsViewModel.kt
@@ -55,7 +55,15 @@ class CallsViewModel
         hasContactsRuntimePermission = PermissionUtils.hasContactsPermission(app)
         getCalls()
         getContacts()
-        checkForUpdate()
+        viewModelScope.launch {
+            callLogPreferences.observeUpdateCheckEnabled().collect { enabled ->
+                if (enabled) {
+                    checkForUpdate()
+                } else {
+                    _availableUpdate.value = null
+                }
+            }
+        }
     }
 
     fun getCalls() {

--- a/feature/calls/src/test/java/dev/alenajam/opendialer/feature/calls/CallsViewModelTest.kt
+++ b/feature/calls/src/test/java/dev/alenajam/opendialer/feature/calls/CallsViewModelTest.kt
@@ -74,6 +74,24 @@ class CallsViewModelTest {
         assertEquals(updateRequestsBeforeContactChange + 1, cacheRepository.updateRequests)
     }
 
+    @Test
+    fun `updates are not checked when update checks are disabled`() = runTest(dispatcher) {
+        val updateChecker = FakeUpdateChecker()
+
+        CallsViewModel(
+            callsRepository = FakeCallsRepository(emptyList()),
+            contactsRepository = FakeContactsRepository(),
+            app = PermissionGrantedApplication(),
+            cacheRepository = FakeCacheRepository(),
+            callPlacementRepository = FakeCallPlacementRepository(),
+            callLogPreferences = FakeCallLogPreferences(updateChecksEnabled = false),
+            updateChecker = updateChecker,
+        )
+        advanceUntilIdle()
+
+        assertEquals(0, updateChecker.checkCount)
+    }
+
     private fun callEntity() = DialerCallEntity(
         id = 1,
         number = "6505551212",
@@ -132,7 +150,9 @@ private class FakeCallPlacementRepository : CallPlacementRepository {
         CallPlacementResult.Placed
 }
 
-private class FakeCallLogPreferences : CallLogPreferences {
+private class FakeCallLogPreferences(
+    private val updateChecksEnabled: Boolean = true,
+) : CallLogPreferences {
     private var favoritesExpanded = true
 
     override fun isFavoritesExpanded(): Boolean = favoritesExpanded
@@ -156,10 +176,17 @@ private class FakeCallLogPreferences : CallLogPreferences {
     override fun getCachedAvailableUpdate(): AppUpdate? = null
 
     override fun setCachedAvailableUpdate(update: AppUpdate?) = Unit
+
+    override fun observeUpdateCheckEnabled(): Flow<Boolean> = MutableStateFlow(updateChecksEnabled)
 }
 
 private class FakeUpdateChecker : UpdateChecker {
-    override suspend fun checkForUpdate(etag: String?): UpdateCheckResult = UpdateCheckResult.Failed
+    var checkCount = 0
+
+    override suspend fun checkForUpdate(etag: String?): UpdateCheckResult {
+        checkCount++
+        return UpdateCheckResult.Failed
+    }
 }
 
 private class FakeContactsRepository : ContactsRepository {

--- a/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsScreen.kt
@@ -7,6 +7,7 @@ import android.telecom.TelecomManager
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -24,14 +25,21 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import dev.alenajam.opendialer.core.common.copy
+import dev.alenajam.opendialer.core.common.SharedPreferenceHelper
 
 private data class SettingsListItem(
     val title: String,
@@ -49,6 +57,9 @@ fun SettingsScreen(
     onOpenSubpage: (Int) -> Unit = {}
 ) {
     val context = LocalContext.current
+    var updateChecksEnabled by remember {
+        mutableStateOf(SharedPreferenceHelper.isUpdateCheckEnabled(context))
+    }
     val canManageBlockedNumbers = BlockedNumberContract.canCurrentUserBlockNumbers(context)
     val appName = stringResource(R.string.app_name)
     val displayOptionsTitle = stringResource(R.string.display_options)
@@ -123,10 +134,48 @@ fun SettingsScreen(
                 title = stringResource(R.string.dialer),
                 items = dialerItems
             )
+            Spacer(Modifier.height(12.dp))
+            UpdateChecksSection(
+                enabled = updateChecksEnabled,
+                onEnabledChange = { enabled ->
+                    updateChecksEnabled = enabled
+                    SharedPreferenceHelper.setUpdateCheckEnabled(context, enabled)
+                },
+            )
             if (extensionItems.isNotEmpty()) {
                 Spacer(Modifier.height(12.dp))
                 SettingsSection(title = extensionTitle, items = extensionItems)
             }
+        }
+    }
+}
+
+@Composable
+private fun UpdateChecksSection(enabled: Boolean, onEnabledChange: (Boolean) -> Unit) {
+    Text(
+        text = stringResource(R.string.update_checks),
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.padding(horizontal = 4.dp, vertical = 8.dp)
+    )
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.5.dp),
+        onClick = { onEnabledChange(!enabled) },
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 16.dp, end = 12.dp, top = 12.dp, bottom = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(stringResource(R.string.check_for_updates), style = MaterialTheme.typography.titleMedium)
+                Text(
+                    stringResource(R.string.check_for_updates_description),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+            Switch(checked = enabled, onCheckedChange = onEnabledChange)
         }
     }
 }

--- a/feature/settings/src/main/res/values-ar/strings.xml
+++ b/feature/settings/src/main/res/values-ar/strings.xml
@@ -37,4 +37,7 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">هل وجدت خطأ أو لديك فكرة؟ افتح بلاغًا على GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">تواصل</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s من تصميم %2$s</string>
+    <string name="update_checks">التحديثات</string>
+    <string name="check_for_updates">التحقق من التحديثات</string>
+    <string name="check_for_updates_description">التحقق من GitHub بحثًا عن إصدارات جديدة</string>
 </resources>

--- a/feature/settings/src/main/res/values-da/strings.xml
+++ b/feature/settings/src/main/res/values-da/strings.xml
@@ -37,4 +37,7 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Har du fundet en fejl eller fået en idé? Opret en sag på GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Kontakt</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s af %2$s</string>
+    <string name="update_checks">Opdateringer</string>
+    <string name="check_for_updates">Søg efter opdateringer</string>
+    <string name="check_for_updates_description">Søg på GitHub efter nye versioner</string>
 </resources>

--- a/feature/settings/src/main/res/values-de/strings.xml
+++ b/feature/settings/src/main/res/values-de/strings.xml
@@ -37,4 +37,7 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Du hast einen Fehler gefunden oder eine Idee? Erstelle ein Issue auf GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Kontakt</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s von %2$s</string>
+    <string name="update_checks">Updates</string>
+    <string name="check_for_updates">Nach Updates suchen</string>
+    <string name="check_for_updates_description">GitHub nach neuen Versionen durchsuchen</string>
 </resources>

--- a/feature/settings/src/main/res/values-es/strings.xml
+++ b/feature/settings/src/main/res/values-es/strings.xml
@@ -37,4 +37,7 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">¿Has encontrado un error o tienes una idea? Abre una incidencia en GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Contacto</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s de %2$s</string>
+    <string name="update_checks">Actualizaciones</string>
+    <string name="check_for_updates">Buscar actualizaciones</string>
+    <string name="check_for_updates_description">Buscar nuevas versiones en GitHub</string>
 </resources>

--- a/feature/settings/src/main/res/values-fr/strings.xml
+++ b/feature/settings/src/main/res/values-fr/strings.xml
@@ -37,4 +37,7 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Vous avez trouvé un bug ou vous avez une idée ? Ouvrez un ticket sur GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Contact</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s par %2$s</string>
+    <string name="update_checks">Mises à jour</string>
+    <string name="check_for_updates">Rechercher des mises à jour</string>
+    <string name="check_for_updates_description">Rechercher de nouvelles versions sur GitHub</string>
 </resources>

--- a/feature/settings/src/main/res/values-it/strings.xml
+++ b/feature/settings/src/main/res/values-it/strings.xml
@@ -37,4 +37,7 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Hai trovato un problema o hai un’idea? Apri una segnalazione su GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Contatti</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s di %2$s</string>
+    <string name="update_checks">Aggiornamenti</string>
+    <string name="check_for_updates">Controlla gli aggiornamenti</string>
+    <string name="check_for_updates_description">Cerca nuove versioni su GitHub</string>
 </resources>

--- a/feature/settings/src/main/res/values-nb/strings.xml
+++ b/feature/settings/src/main/res/values-nb/strings.xml
@@ -37,4 +37,7 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Har du funnet en feil eller har en idé? Opprett en sak på GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Kontakt</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s av %2$s</string>
+    <string name="update_checks">Oppdateringer</string>
+    <string name="check_for_updates">Se etter oppdateringer</string>
+    <string name="check_for_updates_description">Se etter nye versjoner på GitHub</string>
 </resources>

--- a/feature/settings/src/main/res/values-nl/strings.xml
+++ b/feature/settings/src/main/res/values-nl/strings.xml
@@ -37,4 +37,7 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Een fout gevonden of een idee? Open een issue op GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Contact</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s door %2$s</string>
+    <string name="update_checks">Updates</string>
+    <string name="check_for_updates">Controleren op updates</string>
+    <string name="check_for_updates_description">Zoek op GitHub naar nieuwe versies</string>
 </resources>

--- a/feature/settings/src/main/res/values-pt/strings.xml
+++ b/feature/settings/src/main/res/values-pt/strings.xml
@@ -37,4 +37,7 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Encontrou um erro ou teve uma ideia? Abra uma issue no GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Contato</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s por %2$s</string>
+    <string name="update_checks">Atualizações</string>
+    <string name="check_for_updates">Verificar atualizações</string>
+    <string name="check_for_updates_description">Verificar novas versões no GitHub</string>
 </resources>

--- a/feature/settings/src/main/res/values-ro/strings.xml
+++ b/feature/settings/src/main/res/values-ro/strings.xml
@@ -37,4 +37,7 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Ai găsit o eroare sau ai o idee? Deschide o sesizare pe GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Contact</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s de %2$s</string>
+    <string name="update_checks">Actualizări</string>
+    <string name="check_for_updates">Verifică actualizările</string>
+    <string name="check_for_updates_description">Verifică GitHub pentru versiuni noi</string>
 </resources>

--- a/feature/settings/src/main/res/values-zh/strings.xml
+++ b/feature/settings/src/main/res/values-zh/strings.xml
@@ -37,4 +37,7 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">发现错误或有新想法？请在 GitHub 上提交问题。</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">联系方式</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s，作者：%2$s</string>
+    <string name="update_checks">更新</string>
+    <string name="check_for_updates">检查更新</string>
+    <string name="check_for_updates_description">在 GitHub 上检查新版本</string>
 </resources>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -17,6 +17,9 @@
     <string name="display_options" comment="Settings section title for appearance preferences.">Display options</string>
     <string name="display_options_description" comment="Settings section summary for appearance preferences.">Choose how %1$s appears</string>
     <string name="dialer" comment="Settings section title for phone-related preferences.">Dialer</string>
+    <string name="update_checks" comment="Settings section title for update-check preferences.">Updates</string>
+    <string name="check_for_updates" comment="Settings toggle label for enabling automatic update checks.">Check for updates</string>
+    <string name="check_for_updates_description" comment="Settings toggle summary for automatic update checks.">Check GitHub for new versions</string>
     <string name="manageBlockedNumbers" comment="Settings item title that opens the system blocked-number list.">Manage blocked numbers</string>
     <string name="manage_blocked_numbers_description" comment="Settings item summary for reviewing blocked phone numbers.">Review and unblock phone numbers</string>
     <string name="manage_blocked_numbers_unavailable" comment="Message shown when the device has no blocked-number settings screen.">Blocked number settings are not available on this device</string>


### PR DESCRIPTION
## Summary
- add a default-on setting for GitHub update checks
- hide the update banner and prevent future checks when disabled
- add translated labels and unit coverage

## Verification
- ./gradlew :feature:calls:testDebugUnitTest
- ./gradlew :feature:settings:lintDebug
- ./gradlew :app:assembleDebug