### PR TITLE
fix: expose app theme state

### DIFF
--- a/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppProviders.kt
+++ b/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppProviders.kt
@@ -18,6 +18,21 @@ fun AppProviders(
     inCallScreen: @Composable () -> Unit = {},
     content: @Composable () -> Unit
 ) {
+    val darkTheme = rememberAppIsDarkTheme()
+
+    CompositionLocalProvider(
+        LocalAppIcons provides icons,
+        LocalAppThemeExtension provides themeExtension,
+        LocalInCallScreen provides inCallScreen
+    ) {
+        AppTheme(darkTheme = darkTheme) {
+            content()
+        }
+    }
+}
+
+@Composable
+fun rememberAppIsDarkTheme(): Boolean {
     val context = LocalContext.current
     var themeMode by remember { mutableStateOf(SharedPreferenceHelper.getThemeMode(context)) }
     val preferences = remember(context) { SharedPreferenceHelper.getSharedPreferences(context) }
@@ -33,19 +48,9 @@ fun AppProviders(
         onDispose { preferences.unregisterOnSharedPreferenceChangeListener(listener) }
     }
 
-    val darkTheme = when (themeMode) {
+    return when (themeMode) {
         SharedPreferenceHelper.ThemeMode.LIGHT -> false
         SharedPreferenceHelper.ThemeMode.DARK -> true
         SharedPreferenceHelper.ThemeMode.SYSTEM -> systemIsDark
-    }
-
-    CompositionLocalProvider(
-        LocalAppIcons provides icons,
-        LocalAppThemeExtension provides themeExtension,
-        LocalInCallScreen provides inCallScreen
-    ) {
-        AppTheme(darkTheme = darkTheme) {
-            content()
-        }
     }
 }


### PR DESCRIPTION
Exposes rememberAppIsDarkTheme for product UI that selects theme-specific icon assets. Keeps AppProviders using the same shared app-theme state.