### PR TITLE
fix(calls): label blocked call log entries

### DIFF
--- a/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/ContactAvatar.kt
+++ b/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/ContactAvatar.kt
@@ -3,7 +3,6 @@ package dev.alenajam.opendialer.core.common.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
@@ -28,7 +27,7 @@ fun ContactAvatar(
     colorKey: String = contactAvatarColorKey(name),
     fallbackIcon: IconSource = LocalAppIcons.current.accountCircle,
     fallbackIconModifier: Modifier = Modifier.size(24.dp),
-    badgeIcon: IconSource? = null,
+    avatarIcon: IconSource? = null,
     initialTextStyle: TextStyle = MaterialTheme.typography.titleLarge
 ) {
     val contactName = name.orEmpty().trim()
@@ -40,7 +39,14 @@ fun ContactAvatar(
             .clip(CircleShape)
             .background(Color(colors.background))
     ) {
-        if (contactName.isBlank()) {
+        if (avatarIcon != null) {
+            AppIcon(
+                icon = avatarIcon,
+                contentDescription = contentDescription,
+                tint = Color(colors.foreground),
+                modifier = fallbackIconModifier,
+            )
+        } else if (contactName.isBlank()) {
             AppIcon(
                 icon = fallbackIcon,
                 contentDescription = contentDescription,
@@ -55,7 +61,7 @@ fun ContactAvatar(
             )
         }
 
-        if (!photoUri.isNullOrBlank()) {
+        if (avatarIcon == null && !photoUri.isNullOrBlank()) {
             AsyncImage(
                 model = photoUri,
                 contentDescription = contentDescription,
@@ -64,21 +70,5 @@ fun ContactAvatar(
             )
         }
 
-        badgeIcon?.let { icon ->
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .background(MaterialTheme.colorScheme.surface, CircleShape)
-                    .padding(2.dp)
-            ) {
-                AppIcon(
-                    icon = icon,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.size(16.dp),
-                )
-            }
-        }
     }
 }

--- a/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/ContactAvatar.kt
+++ b/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/ContactAvatar.kt
@@ -3,6 +3,7 @@ package dev.alenajam.opendialer.core.common.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
@@ -27,6 +28,7 @@ fun ContactAvatar(
     colorKey: String = contactAvatarColorKey(name),
     fallbackIcon: IconSource = LocalAppIcons.current.accountCircle,
     fallbackIconModifier: Modifier = Modifier.size(24.dp),
+    badgeIcon: IconSource? = null,
     initialTextStyle: TextStyle = MaterialTheme.typography.titleLarge
 ) {
     val contactName = name.orEmpty().trim()
@@ -60,6 +62,23 @@ fun ContactAvatar(
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize()
             )
+        }
+
+        badgeIcon?.let { icon ->
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .background(MaterialTheme.colorScheme.surface, CircleShape)
+                    .padding(2.dp)
+            ) {
+                AppIcon(
+                    icon = icon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(16.dp),
+                )
+            }
         }
     }
 }

--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallDetailData.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallDetailData.kt
@@ -58,6 +58,29 @@ object CallDetailData {
             Calls.DEFAULT_SORT_ORDER
         )
 
+    fun getCursorForNumbers(contentResolver: ContentResolver, numbers: List<String>): Cursor? {
+        if (numbers.isEmpty()) return null
+
+        val placeholders = numbers.joinToString(",") { "?" }
+        return contentResolver.query(
+            URI
+                .buildUpon()
+                .appendQueryParameter(Calls.LIMIT_PARAM_KEY, LIMIT.toString())
+                .build(),
+            projection,
+            """
+                (
+                    ${Calls.PHONE_ACCOUNT_COMPONENT_NAME} IS NULL
+                    OR ${Calls.PHONE_ACCOUNT_COMPONENT_NAME} NOT LIKE 'com.google.android.apps.tachyon%'
+                    OR ${Calls.FEATURES} & ${Calls.FEATURES_VIDEO} == ${Calls.FEATURES_VIDEO}
+                )
+                AND ${Calls.NUMBER} IN ($placeholders)
+            """.trimIndent(),
+            numbers.toTypedArray(),
+            Calls.DEFAULT_SORT_ORDER,
+        )
+    }
+
     fun getData(
         cursor: Cursor,
         voicemailNumbers: Set<String> = emptySet(),

--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallDetailData.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallDetailData.kt
@@ -34,14 +34,10 @@ object CallDetailData {
         Calls.CACHED_NUMBER_TYPE
     )
 
-    /** Filter out:
-     *  - Blocked calls
-     *  - Non-video Duo calls
-     */
+    /** Filter out non-video Duo calls. */
     private val where = { ids: List<Int> ->
         """
-            ${Calls.TYPE} != ${Calls.BLOCKED_TYPE}
-            AND (
+            (
                 ${Calls.PHONE_ACCOUNT_COMPONENT_NAME} IS NULL
                 OR ${Calls.PHONE_ACCOUNT_COMPONENT_NAME} NOT LIKE 'com.google.android.apps.tachyon%'
                 OR ${Calls.FEATURES} & ${Calls.FEATURES_VIDEO} == ${Calls.FEATURES_VIDEO}

--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsData.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsData.kt
@@ -49,11 +49,14 @@ object CallsData {
         Calls.CACHED_NUMBER_TYPE
     )
 
-    /** Filter out non-video Duo calls. */
+    /** Filter out blocked calls and non-video Duo calls. */
     private const val where = """
-            ${Calls.PHONE_ACCOUNT_COMPONENT_NAME} IS NULL
-            OR ${Calls.PHONE_ACCOUNT_COMPONENT_NAME} NOT LIKE 'com.google.android.apps.tachyon%'
-            OR ${Calls.FEATURES} & ${Calls.FEATURES_VIDEO} == ${Calls.FEATURES_VIDEO}
+            ${Calls.TYPE} != ${Calls.BLOCKED_TYPE}
+            AND (
+                ${Calls.PHONE_ACCOUNT_COMPONENT_NAME} IS NULL
+                OR ${Calls.PHONE_ACCOUNT_COMPONENT_NAME} NOT LIKE 'com.google.android.apps.tachyon%'
+                OR ${Calls.FEATURES} & ${Calls.FEATURES_VIDEO} == ${Calls.FEATURES_VIDEO}
+            )
         """
 
     fun getCursor(contentResolver: ContentResolver, uri: Uri): Cursor? = contentResolver.query(

--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsData.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsData.kt
@@ -49,17 +49,11 @@ object CallsData {
         Calls.CACHED_NUMBER_TYPE
     )
 
-    /** Filter out:
-     *  - Blocked calls
-     *  - Non-video Duo calls
-     */
+    /** Filter out non-video Duo calls. */
     private const val where = """
-            ${Calls.TYPE} != ${Calls.BLOCKED_TYPE}
-            AND (
-                ${Calls.PHONE_ACCOUNT_COMPONENT_NAME} IS NULL
-                OR ${Calls.PHONE_ACCOUNT_COMPONENT_NAME} NOT LIKE 'com.google.android.apps.tachyon%'
-                OR ${Calls.FEATURES} & ${Calls.FEATURES_VIDEO} == ${Calls.FEATURES_VIDEO}
-            )
+            ${Calls.PHONE_ACCOUNT_COMPONENT_NAME} IS NULL
+            OR ${Calls.PHONE_ACCOUNT_COMPONENT_NAME} NOT LIKE 'com.google.android.apps.tachyon%'
+            OR ${Calls.FEATURES} & ${Calls.FEATURES_VIDEO} == ${Calls.FEATURES_VIDEO}
         """
 
     fun getCursor(contentResolver: ContentResolver, uri: Uri): Cursor? = contentResolver.query(

--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsRepositoryImpl.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsRepositoryImpl.kt
@@ -49,13 +49,22 @@ class CallsRepositoryImpl @Inject constructor(
     override suspend fun getCallByIds(
         ids: List<Int>
     ): Either<Failure, List<DialerCallEntity>> {
-        val data = CallDetailData.getCursor(app.contentResolver, ids)?.use { cursor ->
+        val selectedCalls = CallDetailData.getCursor(app.contentResolver, ids)?.use { cursor ->
             CallDetailData.getData(
                 cursor = cursor,
                 voicemailNumbers = voicemailNumberProvider.getNumbers(),
                 contactPhoneTypes = getContactPhoneTypes(app.contentResolver),
             )
         } ?: return Either.Left(Failure.NoData)
+
+        val numbers = selectedCalls.mapNotNull { it.number }.distinct()
+        val data = CallDetailData.getCursorForNumbers(app.contentResolver, numbers)?.use { cursor ->
+            CallDetailData.getData(
+                cursor = cursor,
+                voicemailNumbers = voicemailNumberProvider.getNumbers(),
+                contactPhoneTypes = getContactPhoneTypes(app.contentResolver),
+            )
+        } ?: selectedCalls
 
         return if (data.isEmpty()) {
             Either.Left(Failure.NoData)

--- a/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/CallDetailScreen.kt
+++ b/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/CallDetailScreen.kt
@@ -193,6 +193,7 @@ private fun TopBar(
 ) {
     val canBlock = options.any { it.id == CallOption.ID_BLOCK_CALLER }
     val canUnblock = options.any { it.id == CallOption.ID_UNBLOCK_CALLER }
+    val isNumberBlocked = canUnblock
     var menuExpanded by remember { mutableStateOf(false) }
     var showBlockConfirmation by remember { mutableStateOf(false) }
 
@@ -236,6 +237,7 @@ private fun TopBar(
                         } else {
                             LocalAppIcons.current.accountCircle
                         },
+                        badgeIcon = if (isNumberBlocked) LocalAppIcons.current.block else null,
                         contentDescription = if (call.isVoicemailNumber) {
                             stringResource(R.string.voicemail)
                         } else {
@@ -244,7 +246,7 @@ private fun TopBar(
                         modifier = Modifier.size(50.dp)
                     )
                     Spacer(modifier = Modifier.size(8.dp))
-                    CallDetailTitle(call)
+                    CallDetailTitle(call, isNumberBlocked)
                 }
             }
         },
@@ -289,7 +291,7 @@ private fun TopBar(
 }
 
 @Composable
-private fun CallDetailTitle(call: DialerCall) {
+private fun CallDetailTitle(call: DialerCall, isNumberBlocked: Boolean) {
     val displayNumber = call.contactInfo.formattedNumber
         ?.takeIf { it.isNotBlank() }
         ?: call.contactInfo.number.orEmpty()
@@ -313,7 +315,7 @@ private fun CallDetailTitle(call: DialerCall) {
             Column {
                 Text(contact.name!!.trim().substringBefore(' '))
                 Text(
-                    text = stringResource(
+                    text = if (isNumberBlocked) stringResource(R.string.blocked) else stringResource(
                         R.string.call_detail_contact_subtitle,
                         phoneType,
                         displayNumber,
@@ -323,7 +325,20 @@ private fun CallDetailTitle(call: DialerCall) {
                 )
             }
         }
-        else -> Text(displayNumber)
+        else -> {
+            if (isNumberBlocked) {
+                Column {
+                    Text(displayNumber)
+                    Text(
+                        text = stringResource(R.string.blocked),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else {
+                Text(displayNumber)
+            }
+        }
     }
 }
 

--- a/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/CallDetailScreen.kt
+++ b/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/CallDetailScreen.kt
@@ -237,7 +237,7 @@ private fun TopBar(
                         } else {
                             LocalAppIcons.current.accountCircle
                         },
-                        badgeIcon = if (isNumberBlocked) LocalAppIcons.current.block else null,
+                        avatarIcon = if (isNumberBlocked) LocalAppIcons.current.block else null,
                         contentDescription = if (call.isVoicemailNumber) {
                             stringResource(R.string.voicemail)
                         } else {

--- a/feature/callDetail/src/main/res/values-ar/strings.xml
+++ b/feature/callDetail/src/main/res/values-ar/strings.xml
@@ -16,6 +16,7 @@
     <string name="missed_call" comment="Call-detail label identifying a missed incoming call.">مكالمة فائتة</string>
     <string name="rejected_call" comment="Call-detail label identifying an incoming call that was declined.">مكالمة مرفوضة</string>
     <string name="blocked_call" comment="Call-detail label identifying a call that was blocked.">مكالمة محظورة</string>
+    <string name="blocked" comment="Call-detail subtitle identifying a blocked number.">محظور</string>
     <string name="voicemail_call" comment="Call-detail label identifying a voicemail entry.">رسالة بريد صوتي</string>
     <string name="voicemail" comment="Label for voicemail in navigation or call information.">البريد الصوتي</string>
     <string name="block_confirmation_title" comment="Title of the block-caller confirmation dialog. %1$s is the caller name or phone number.">هل تريد حظر %1$s؟</string>

--- a/feature/callDetail/src/main/res/values-da/strings.xml
+++ b/feature/callDetail/src/main/res/values-da/strings.xml
@@ -16,6 +16,7 @@
     <string name="missed_call" comment="Call-detail label identifying a missed incoming call.">Ubesvaret opkald</string>
     <string name="rejected_call" comment="Call-detail label identifying an incoming call that was declined.">Afvist opkald</string>
     <string name="blocked_call" comment="Call-detail label identifying a call that was blocked.">Blokeret opkald</string>
+    <string name="blocked" comment="Call-detail subtitle identifying a blocked number.">Blokeret</string>
     <string name="voicemail_call" comment="Call-detail label identifying a voicemail entry.">Besked på telefonsvareren</string>
     <string name="voicemail" comment="Label for voicemail in navigation or call information.">Telefonsvarer</string>
     <string name="block_confirmation_title" comment="Title of the block-caller confirmation dialog. %1$s is the caller name or phone number.">Vil du blokere %1$s?</string>

--- a/feature/callDetail/src/main/res/values-de/strings.xml
+++ b/feature/callDetail/src/main/res/values-de/strings.xml
@@ -16,6 +16,7 @@
     <string name="missed_call" comment="Call-detail label identifying a missed incoming call.">Verpasster Anruf</string>
     <string name="rejected_call" comment="Call-detail label identifying an incoming call that was declined.">Abgewiesener Anruf</string>
     <string name="blocked_call" comment="Call-detail label identifying a call that was blocked.">Blockierter Anruf</string>
+    <string name="blocked" comment="Call-detail subtitle identifying a blocked number.">Blockiert</string>
     <string name="voicemail_call" comment="Call-detail label identifying a voicemail entry.">Mailboxnachricht</string>
     <string name="voicemail" comment="Label for voicemail in navigation or call information.">Mailbox</string>
     <string name="block_confirmation_title" comment="Title of the block-caller confirmation dialog. %1$s is the caller name or phone number.">%1$s blockieren?</string>

--- a/feature/callDetail/src/main/res/values-es/strings.xml
+++ b/feature/callDetail/src/main/res/values-es/strings.xml
@@ -16,6 +16,7 @@
     <string name="missed_call" comment="Call-detail label identifying a missed incoming call.">Llamada perdida</string>
     <string name="rejected_call" comment="Call-detail label identifying an incoming call that was declined.">Llamada rechazada</string>
     <string name="blocked_call" comment="Call-detail label identifying a call that was blocked.">Llamada bloqueada</string>
+    <string name="blocked" comment="Call-detail subtitle identifying a blocked number.">Bloqueada</string>
     <string name="voicemail_call" comment="Call-detail label identifying a voicemail entry.">Mensaje de voz</string>
     <string name="voicemail" comment="Label for voicemail in navigation or call information.">Buzón de voz</string>
     <string name="block_confirmation_title" comment="Title of the block-caller confirmation dialog. %1$s is the caller name or phone number.">¿Bloquear a %1$s?</string>

--- a/feature/callDetail/src/main/res/values-fr/strings.xml
+++ b/feature/callDetail/src/main/res/values-fr/strings.xml
@@ -16,6 +16,7 @@
     <string name="missed_call" comment="Call-detail label identifying a missed incoming call.">Appel manqué</string>
     <string name="rejected_call" comment="Call-detail label identifying an incoming call that was declined.">Appel refusé</string>
     <string name="blocked_call" comment="Call-detail label identifying a call that was blocked.">Appel bloqué</string>
+    <string name="blocked" comment="Call-detail subtitle identifying a blocked number.">Bloqué</string>
     <string name="voicemail_call" comment="Call-detail label identifying a voicemail entry.">Message vocal</string>
     <string name="voicemail" comment="Label for voicemail in navigation or call information.">Messagerie vocale</string>
     <string name="block_confirmation_title" comment="Title of the block-caller confirmation dialog. %1$s is the caller name or phone number.">Bloquer %1$s ?</string>

--- a/feature/callDetail/src/main/res/values-it/strings.xml
+++ b/feature/callDetail/src/main/res/values-it/strings.xml
@@ -16,6 +16,7 @@
     <string name="missed_call" comment="Call-detail label identifying a missed incoming call.">Chiamata persa</string>
     <string name="rejected_call" comment="Call-detail label identifying an incoming call that was declined.">Chiamata rifiutata</string>
     <string name="blocked_call" comment="Call-detail label identifying a call that was blocked.">Chiamata bloccata</string>
+    <string name="blocked" comment="Call-detail subtitle identifying a blocked number.">Bloccata</string>
     <string name="voicemail_call" comment="Call-detail label identifying a voicemail entry.">Messaggio in segreteria</string>
     <string name="voicemail" comment="Label for voicemail in navigation or call information.">Segreteria</string>
     <string name="block_confirmation_title" comment="Title of the block-caller confirmation dialog. %1$s is the caller name or phone number.">Bloccare %1$s?</string>

--- a/feature/callDetail/src/main/res/values-nb/strings.xml
+++ b/feature/callDetail/src/main/res/values-nb/strings.xml
@@ -16,6 +16,7 @@
     <string name="missed_call" comment="Call-detail label identifying a missed incoming call.">Tapt anrop</string>
     <string name="rejected_call" comment="Call-detail label identifying an incoming call that was declined.">Avvist samtale</string>
     <string name="blocked_call" comment="Call-detail label identifying a call that was blocked.">Blokkert samtale</string>
+    <string name="blocked" comment="Call-detail subtitle identifying a blocked number.">Blokkert</string>
     <string name="voicemail_call" comment="Call-detail label identifying a voicemail entry.">Talepostmelding</string>
     <string name="voicemail" comment="Label for voicemail in navigation or call information.">Talepost</string>
     <string name="block_confirmation_title" comment="Title of the block-caller confirmation dialog. %1$s is the caller name or phone number.">Blokkere %1$s?</string>

--- a/feature/callDetail/src/main/res/values-nl/strings.xml
+++ b/feature/callDetail/src/main/res/values-nl/strings.xml
@@ -16,6 +16,7 @@
     <string name="missed_call" comment="Call-detail label identifying a missed incoming call.">Gemiste oproep</string>
     <string name="rejected_call" comment="Call-detail label identifying an incoming call that was declined.">Geweigerde oproep</string>
     <string name="blocked_call" comment="Call-detail label identifying a call that was blocked.">Geblokkeerde oproep</string>
+    <string name="blocked" comment="Call-detail subtitle identifying a blocked number.">Geblokkeerd</string>
     <string name="voicemail_call" comment="Call-detail label identifying a voicemail entry.">Voicemailbericht</string>
     <string name="voicemail" comment="Label for voicemail in navigation or call information.">Voicemail</string>
     <string name="block_confirmation_title" comment="Title of the block-caller confirmation dialog. %1$s is the caller name or phone number.">%1$s blokkeren?</string>

--- a/feature/callDetail/src/main/res/values-pt/strings.xml
+++ b/feature/callDetail/src/main/res/values-pt/strings.xml
@@ -16,6 +16,7 @@
     <string name="missed_call" comment="Call-detail label identifying a missed incoming call.">Chamada perdida</string>
     <string name="rejected_call" comment="Call-detail label identifying an incoming call that was declined.">Chamada recusada</string>
     <string name="blocked_call" comment="Call-detail label identifying a call that was blocked.">Chamada bloqueada</string>
+    <string name="blocked" comment="Call-detail subtitle identifying a blocked number.">Bloqueada</string>
     <string name="voicemail_call" comment="Call-detail label identifying a voicemail entry.">Mensagem de voz</string>
     <string name="voicemail" comment="Label for voicemail in navigation or call information.">Correio de voz</string>
     <string name="block_confirmation_title" comment="Title of the block-caller confirmation dialog. %1$s is the caller name or phone number.">Bloquear %1$s?</string>

--- a/feature/callDetail/src/main/res/values-ro/strings.xml
+++ b/feature/callDetail/src/main/res/values-ro/strings.xml
@@ -16,6 +16,7 @@
     <string name="missed_call" comment="Call-detail label identifying a missed incoming call.">Apel pierdut</string>
     <string name="rejected_call" comment="Call-detail label identifying an incoming call that was declined.">Apel respins</string>
     <string name="blocked_call" comment="Call-detail label identifying a call that was blocked.">Apel blocat</string>
+    <string name="blocked" comment="Call-detail subtitle identifying a blocked number.">Blocat</string>
     <string name="voicemail_call" comment="Call-detail label identifying a voicemail entry.">Mesaj vocal</string>
     <string name="voicemail" comment="Label for voicemail in navigation or call information.">Mesagerie vocală</string>
     <string name="block_confirmation_title" comment="Title of the block-caller confirmation dialog. %1$s is the caller name or phone number.">Blochezi %1$s?</string>

--- a/feature/callDetail/src/main/res/values-zh/strings.xml
+++ b/feature/callDetail/src/main/res/values-zh/strings.xml
@@ -16,6 +16,7 @@
     <string name="missed_call" comment="Call-detail label identifying a missed incoming call.">未接来电</string>
     <string name="rejected_call" comment="Call-detail label identifying an incoming call that was declined.">已拒接来电</string>
     <string name="blocked_call" comment="Call-detail label identifying a call that was blocked.">已屏蔽来电</string>
+    <string name="blocked" comment="Call-detail subtitle identifying a blocked number.">已屏蔽</string>
     <string name="voicemail_call" comment="Call-detail label identifying a voicemail entry.">语音留言</string>
     <string name="voicemail" comment="Label for voicemail in navigation or call information.">语音信箱</string>
     <string name="block_confirmation_title" comment="Title of the block-caller confirmation dialog. %1$s is the caller name or phone number.">屏蔽 %1$s？</string>

--- a/feature/callDetail/src/main/res/values/strings.xml
+++ b/feature/callDetail/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="missed_call" comment="Call-detail label identifying a missed incoming call.">Missed call</string>
     <string name="rejected_call" comment="Call-detail label identifying an incoming call that was declined.">Rejected call</string>
     <string name="blocked_call" comment="Call-detail label identifying a call that was blocked.">Blocked call</string>
+    <string name="blocked" comment="Call-detail subtitle identifying a blocked number.">Blocked</string>
     <string name="voicemail_call" comment="Call-detail label identifying a voicemail entry.">Voicemail Call</string>
     <string name="voicemail" comment="Label for voicemail in navigation or call information.">Voicemail</string>
     <string name="block_confirmation_title" comment="Title of the block-caller confirmation dialog. %1$s is the caller name or phone number.">Block %1$s?</string>

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
@@ -57,7 +57,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -501,21 +501,25 @@ private fun CallRow(
     var showBlockConfirmation by remember { mutableStateOf(false) }
     var showDeleteConfirmation by remember { mutableStateOf(false) }
     var isNumberBlocked by remember(call.id) { mutableStateOf(false) }
-    val resources = LocalContext.current.resources
+    val resources = LocalResources.current
     val locale = LocalConfiguration.current.locales[0]
     val callDate = call.date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
     val relativeTime = if (callDate == today) PrettyTime().format(call.date)
     else formatCallLogTime(call.date, locale)
-    val phoneType = call.contactInfo.type
-        ?.takeIf { call.isContactSaved() }
-        ?.let {
-            ContactsContract.CommonDataKinds.Phone.getTypeLabel(
-                resources,
-                it,
-                call.contactInfo.label,
-            ).toString()
-        }
-        .orEmpty()
+    val callLabel = if (call.type == CallType.BLOCKED) {
+        stringResource(R.string.blocked)
+    } else {
+        call.contactInfo.type
+            ?.takeIf { call.isContactSaved() }
+            ?.let {
+                ContactsContract.CommonDataKinds.Phone.getTypeLabel(
+                    resources,
+                    it,
+                    call.contactInfo.label,
+                ).toString()
+            }
+            .orEmpty()
+    }
     val displayNumber = call.contactInfo.formattedNumber
         ?.takeIf { it.isNotBlank() }
         ?: call.contactInfo.number.orEmpty()
@@ -623,10 +627,10 @@ private fun CallRow(
                         )
 
                         Text(
-                            text = if (phoneType.isBlank()) {
+                            text = if (callLabel.isBlank()) {
                                 relativeTime
                             } else {
-                                stringResource(R.string.call_log_type_time, phoneType, relativeTime)
+                                stringResource(R.string.call_log_type_time, callLabel, relativeTime)
                             },
                             style = MaterialTheme.typography.bodyMedium,
                             color = subtitleColor

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
@@ -708,21 +708,15 @@ private fun CallRow(
                         onClick = openHistory,
                     )
 
-                    if (!call.isAnonymous()) {
+                    if (!call.isAnonymous() && isNumberBlocked) {
                         CallRowButton(
-                            label = stringResource(
-                                if (isNumberBlocked) R.string.unblockThisCaller else R.string.blockThisCaller,
-                            ),
+                            label = stringResource(R.string.unblockThisCaller),
                             icon = icons.block,
                             roundBottom = true,
                             onClick = {
-                                if (isNumberBlocked) {
-                                    unblockNumber()
-                                    isNumberBlocked = false
-                                    onBlockStatusChanged(false)
-                                } else {
-                                    showBlockConfirmation = true
-                                }
+                                unblockNumber()
+                                isNumberBlocked = false
+                                onBlockStatusChanged(false)
                             },
                         )
                     }

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
@@ -531,7 +531,7 @@ private fun CallRow(
     LaunchedEffect(isBlocked) {
         isNumberBlocked = isBlocked
     }
-    val callLabel = if (isNumberBlocked || call.type == CallType.BLOCKED) {
+    val callLabel = if (isNumberBlocked) {
         stringResource(R.string.blocked)
     } else {
         call.contactInfo.type
@@ -592,7 +592,7 @@ private fun CallRow(
                     } else {
                         icons.accountCircle
                     },
-                    avatarIcon = if (isNumberBlocked || call.type == CallType.BLOCKED) icons.block else null,
+                    avatarIcon = if (isNumberBlocked) icons.block else null,
                     contentDescription = if (call.isVoicemailNumber) {
                         stringResource(R.string.filter_voicemail)
                     } else if (call.isContactSaved()) {

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
@@ -1,6 +1,7 @@
 package dev.alenajam.opendialer.feature.calls
 
 import android.provider.ContactsContract
+import android.telephony.PhoneNumberUtils
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
@@ -47,6 +48,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -146,6 +148,7 @@ fun CallsScreen(
     val availableUpdate by viewModel.availableUpdate.collectAsStateWithLifecycle()
     var openRowId by remember { mutableStateOf<Int?>(null) }
     var selectedFilter by remember { mutableStateOf(CallFilter.ALL) }
+    var blockedNumbers by remember { mutableStateOf<Set<String>>(emptySet()) }
 
     val icons = LocalAppIcons.current
     val filteredCalls = remember(calls.value, selectedFilter) {
@@ -256,9 +259,15 @@ fun CallsScreen(
                     }
                     itemsIndexed(callsForDate, key = { _, call -> call.id }) { index, call ->
                         val isOpen = openRowId == call.id
+                        val isNumberBlocked = call.contactInfo.number?.let { number ->
+                            blockedNumbers.any { blockedNumber ->
+                                PhoneNumberUtils.compare(blockedNumber, number)
+                            }
+                        } == true
 
                         CallRow(call = call,
                             isOpen = isOpen,
+                            isBlocked = isNumberBlocked,
                             today = today,
                             roundTop = index == 0,
                             roundBottom = index == callsForDate.lastIndex,
@@ -274,6 +283,11 @@ fun CallsScreen(
                             blockNumber = { viewModel.blockNumber(call.contactInfo.number!!) },
                             unblockNumber = { viewModel.unblockNumber(call.contactInfo.number!!) },
                             refreshBlockStatus = { onResult -> viewModel.getBlockStatus(call, onResult) },
+                            onBlockStatusChanged = { isBlocked ->
+                                call.contactInfo.number?.let { number ->
+                                    blockedNumbers = if (isBlocked) blockedNumbers + number else blockedNumbers - number
+                                }
+                            },
                             deleteCall = { viewModel.deleteCall(call) }
                         )
                     }
@@ -480,6 +494,7 @@ private fun CallDateHeader(date: LocalDate, today: LocalDate) {
 private fun CallRow(
     call: DialerCall,
     isOpen: Boolean,
+    isBlocked: Boolean,
     today: LocalDate = LocalDate.now(),
     roundTop: Boolean,
     roundBottom: Boolean,
@@ -495,18 +510,28 @@ private fun CallRow(
     blockNumber: () -> Unit,
     unblockNumber: () -> Unit,
     refreshBlockStatus: ((Boolean) -> Unit) -> Unit,
+    onBlockStatusChanged: (Boolean) -> Unit,
     deleteCall: () -> Unit,
 ) {
     var contextMenuExpanded by remember { mutableStateOf(false) }
     var showBlockConfirmation by remember { mutableStateOf(false) }
     var showDeleteConfirmation by remember { mutableStateOf(false) }
-    var isNumberBlocked by remember(call.id) { mutableStateOf(false) }
+    var isNumberBlocked by remember(call.id) { mutableStateOf(isBlocked) }
     val resources = LocalResources.current
     val locale = LocalConfiguration.current.locales[0]
     val callDate = call.date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
     val relativeTime = if (callDate == today) PrettyTime().format(call.date)
     else formatCallLogTime(call.date, locale)
-    val callLabel = if (call.type == CallType.BLOCKED) {
+    LaunchedEffect(call.id) {
+        refreshBlockStatus { blocked ->
+            isNumberBlocked = blocked
+            onBlockStatusChanged(blocked)
+        }
+    }
+    LaunchedEffect(isBlocked) {
+        isNumberBlocked = isBlocked
+    }
+    val callLabel = if (isNumberBlocked || call.type == CallType.BLOCKED) {
         stringResource(R.string.blocked)
     } else {
         call.contactInfo.type
@@ -543,6 +568,7 @@ private fun CallRow(
                     onLongClick = {
                         refreshBlockStatus { isBlocked ->
                             isNumberBlocked = isBlocked
+                            onBlockStatusChanged(isBlocked)
                             contextMenuExpanded = true
                         }
                     }
@@ -566,6 +592,7 @@ private fun CallRow(
                     } else {
                         icons.accountCircle
                     },
+                    badgeIcon = if (isNumberBlocked || call.type == CallType.BLOCKED) icons.block else null,
                     contentDescription = if (call.isVoicemailNumber) {
                         stringResource(R.string.filter_voicemail)
                     } else if (call.isContactSaved()) {
@@ -677,9 +704,28 @@ private fun CallRow(
                         label = stringResource(R.string.history),
                         icon = icons.history,
                         roundTop = call.isAnonymous(),
-                        roundBottom = true,
+                        roundBottom = call.isAnonymous(),
                         onClick = openHistory,
                     )
+
+                    if (!call.isAnonymous()) {
+                        CallRowButton(
+                            label = stringResource(
+                                if (isNumberBlocked) R.string.unblockThisCaller else R.string.blockThisCaller,
+                            ),
+                            icon = icons.block,
+                            roundBottom = true,
+                            onClick = {
+                                if (isNumberBlocked) {
+                                    unblockNumber()
+                                    isNumberBlocked = false
+                                    onBlockStatusChanged(false)
+                                } else {
+                                    showBlockConfirmation = true
+                                }
+                            },
+                        )
+                    }
                 }
             }
         }
@@ -703,6 +749,7 @@ private fun CallRow(
                         contextMenuExpanded = false
                         unblockNumber()
                         isNumberBlocked = false
+                        onBlockStatusChanged(false)
                     })
                 } else {
                     DropdownMenuItem(text = { Text(stringResource(R.string.blockThisCaller)) }, onClick = {
@@ -728,6 +775,7 @@ private fun CallRow(
                     showBlockConfirmation = false
                     blockNumber()
                     isNumberBlocked = true
+                    onBlockStatusChanged(true)
                 }) { Text(stringResource(R.string.blockThisCaller)) }
             },
             dismissButton = { TextButton(onClick = { showBlockConfirmation = false }) { Text(stringResource(R.string.cancel)) } }
@@ -803,6 +851,7 @@ private val anonymousCallMock = incomingCallMock.copy(
 private fun IncomingCallPreview() {
     CallRow(call = incomingCallMock,
         isOpen = false,
+        isBlocked = false,
         roundTop = true,
         roundBottom = true,
         icons = dev.alenajam.opendialer.core.common.ui.DefaultAppIcons,
@@ -817,6 +866,7 @@ private fun IncomingCallPreview() {
         blockNumber = {},
         unblockNumber = {},
         refreshBlockStatus = {},
+        onBlockStatusChanged = {},
         deleteCall = {})
 }
 
@@ -825,6 +875,7 @@ private fun IncomingCallPreview() {
 private fun OutgoingCallPreview() {
     CallRow(call = outgoingCallMock,
         isOpen = false,
+        isBlocked = false,
         roundTop = true,
         roundBottom = true,
         icons = dev.alenajam.opendialer.core.common.ui.DefaultAppIcons,
@@ -839,6 +890,7 @@ private fun OutgoingCallPreview() {
         blockNumber = {},
         unblockNumber = {},
         refreshBlockStatus = {},
+        onBlockStatusChanged = {},
         deleteCall = {})
 }
 
@@ -847,6 +899,7 @@ private fun OutgoingCallPreview() {
 private fun AnonymousCallPreview() {
     CallRow(call = anonymousCallMock,
         isOpen = false,
+        isBlocked = false,
         roundTop = true,
         roundBottom = true,
         icons = dev.alenajam.opendialer.core.common.ui.DefaultAppIcons,
@@ -861,5 +914,6 @@ private fun AnonymousCallPreview() {
         blockNumber = {},
         unblockNumber = {},
         refreshBlockStatus = {},
+        onBlockStatusChanged = {},
         deleteCall = {})
 }

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
@@ -592,7 +592,7 @@ private fun CallRow(
                     } else {
                         icons.accountCircle
                     },
-                    badgeIcon = if (isNumberBlocked || call.type == CallType.BLOCKED) icons.block else null,
+                    avatarIcon = if (isNumberBlocked || call.type == CallType.BLOCKED) icons.block else null,
                     contentDescription = if (call.isVoicemailNumber) {
                         stringResource(R.string.filter_voicemail)
                     } else if (call.isContactSaved()) {

--- a/feature/calls/src/main/res/values-ar/strings.xml
+++ b/feature/calls/src/main/res/values-ar/strings.xml
@@ -9,6 +9,7 @@
     <string name="unblockThisCaller" comment="Menu action that removes the block from the selected caller.">إلغاء حظر هذا المتصل</string>
     <string name="delete" comment="Menu action that deletes the selected call-log entry.">حذف</string>
     <string name="anonymous" comment="Fallback caller name when the phone number is withheld.">مجهول</string>
+    <string name="blocked" comment="Call-log label identifying a call that was blocked.">محظور</string>
     <string name="placeholder_call_log" comment="Empty-state message shown when phone permission is required to display call history.">لعرض سجل المكالمات، فعّل أذونات الهاتف</string>
     <string name="turn_on" comment="Button that opens settings to grant the permission required by the current screen.">تفعيل</string>
     <string name="open_contact" comment="Menu action that opens the selected person's contact details.">فتح جهة الاتصال</string>

--- a/feature/calls/src/main/res/values-da/strings.xml
+++ b/feature/calls/src/main/res/values-da/strings.xml
@@ -9,6 +9,7 @@
     <string name="unblockThisCaller" comment="Menu action that removes the block from the selected caller.">Fjern blokering af denne person</string>
     <string name="delete" comment="Menu action that deletes the selected call-log entry.">Slet</string>
     <string name="anonymous" comment="Fallback caller name when the phone number is withheld.">Anonym</string>
+    <string name="blocked" comment="Call-log label identifying a call that was blocked.">Blokeret</string>
     <string name="placeholder_call_log" comment="Empty-state message shown when phone permission is required to display call history.">Slå telefontilladelser til for at se din opkaldshistorik</string>
     <string name="turn_on" comment="Button that opens settings to grant the permission required by the current screen.">Slå til</string>
     <string name="open_contact" comment="Menu action that opens the selected person's contact details.">Åbn kontakt</string>

--- a/feature/calls/src/main/res/values-de/strings.xml
+++ b/feature/calls/src/main/res/values-de/strings.xml
@@ -9,6 +9,7 @@
     <string name="unblockThisCaller" comment="Menu action that removes the block from the selected caller.">Anrufer nicht mehr blockieren</string>
     <string name="delete" comment="Menu action that deletes the selected call-log entry.">Löschen</string>
     <string name="anonymous" comment="Fallback caller name when the phone number is withheld.">Anonym</string>
+    <string name="blocked" comment="Call-log label identifying a call that was blocked.">Blockiert</string>
     <string name="placeholder_call_log" comment="Empty-state message shown when phone permission is required to display call history.">Aktiviere die Telefonberechtigungen, um deine Anrufliste zu sehen</string>
     <string name="turn_on" comment="Button that opens settings to grant the permission required by the current screen.">Aktivieren</string>
     <string name="open_contact" comment="Menu action that opens the selected person's contact details.">Kontakt öffnen</string>

--- a/feature/calls/src/main/res/values-es/strings.xml
+++ b/feature/calls/src/main/res/values-es/strings.xml
@@ -9,6 +9,7 @@
     <string name="unblockThisCaller" comment="Menu action that removes the block from the selected caller.">Desbloquear a este emisor</string>
     <string name="delete" comment="Menu action that deletes the selected call-log entry.">Eliminar</string>
     <string name="anonymous" comment="Fallback caller name when the phone number is withheld.">Anónimo</string>
+    <string name="blocked" comment="Call-log label identifying a call that was blocked.">Bloqueada</string>
     <string name="placeholder_call_log" comment="Empty-state message shown when phone permission is required to display call history.">Activa los permisos del teléfono para ver el historial de llamadas</string>
     <string name="turn_on" comment="Button that opens settings to grant the permission required by the current screen.">Activar</string>
     <string name="open_contact" comment="Menu action that opens the selected person's contact details.">Abrir contacto</string>

--- a/feature/calls/src/main/res/values-fr/strings.xml
+++ b/feature/calls/src/main/res/values-fr/strings.xml
@@ -9,6 +9,7 @@
     <string name="unblockThisCaller" comment="Menu action that removes the block from the selected caller.">Débloquer cet appelant</string>
     <string name="delete" comment="Menu action that deletes the selected call-log entry.">Supprimer</string>
     <string name="anonymous" comment="Fallback caller name when the phone number is withheld.">Anonyme</string>
+    <string name="blocked" comment="Call-log label identifying a call that was blocked.">Bloqué</string>
     <string name="placeholder_call_log" comment="Empty-state message shown when phone permission is required to display call history.">Activez les autorisations Téléphone pour afficher votre historique des appels</string>
     <string name="turn_on" comment="Button that opens settings to grant the permission required by the current screen.">Activer</string>
     <string name="open_contact" comment="Menu action that opens the selected person's contact details.">Ouvrir le contact</string>

--- a/feature/calls/src/main/res/values-it/strings.xml
+++ b/feature/calls/src/main/res/values-it/strings.xml
@@ -9,6 +9,7 @@
     <string name="unblockThisCaller" comment="Menu action that removes the block from the selected caller.">Sblocca questo chiamante</string>
     <string name="delete" comment="Menu action that deletes the selected call-log entry.">Elimina</string>
     <string name="anonymous" comment="Fallback caller name when the phone number is withheld.">Anonimo</string>
+    <string name="blocked" comment="Call-log label identifying a call that was blocked.">Bloccata</string>
     <string name="placeholder_call_log" comment="Empty-state message shown when phone permission is required to display call history.">Per visualizzare la cronologia delle chiamate, consenti l’accesso al telefono</string>
     <string name="turn_on" comment="Button that opens settings to grant the permission required by the current screen.">Attiva</string>
     <string name="open_contact" comment="Menu action that opens the selected person's contact details.">Apri contatto</string>

--- a/feature/calls/src/main/res/values-nb/strings.xml
+++ b/feature/calls/src/main/res/values-nb/strings.xml
@@ -9,6 +9,7 @@
     <string name="unblockThisCaller" comment="Menu action that removes the block from the selected caller.">Opphev blokkering av denne innringeren</string>
     <string name="delete" comment="Menu action that deletes the selected call-log entry.">Slett</string>
     <string name="anonymous" comment="Fallback caller name when the phone number is withheld.">Anonym</string>
+    <string name="blocked" comment="Call-log label identifying a call that was blocked.">Blokkert</string>
     <string name="placeholder_call_log" comment="Empty-state message shown when phone permission is required to display call history.">Slå på telefontillatelser for å se anropsloggen</string>
     <string name="turn_on" comment="Button that opens settings to grant the permission required by the current screen.">Slå på</string>
     <string name="open_contact" comment="Menu action that opens the selected person's contact details.">Åpne kontakt</string>

--- a/feature/calls/src/main/res/values-nl/strings.xml
+++ b/feature/calls/src/main/res/values-nl/strings.xml
@@ -9,6 +9,7 @@
     <string name="unblockThisCaller" comment="Menu action that removes the block from the selected caller.">Deze beller deblokkeren</string>
     <string name="delete" comment="Menu action that deletes the selected call-log entry.">Verwijderen</string>
     <string name="anonymous" comment="Fallback caller name when the phone number is withheld.">Anoniem</string>
+    <string name="blocked" comment="Call-log label identifying a call that was blocked.">Geblokkeerd</string>
     <string name="placeholder_call_log" comment="Empty-state message shown when phone permission is required to display call history.">Schakel de telefoonmachtigingen in om je oproepgeschiedenis te bekijken</string>
     <string name="turn_on" comment="Button that opens settings to grant the permission required by the current screen.">Inschakelen</string>
     <string name="open_contact" comment="Menu action that opens the selected person's contact details.">Contact openen</string>

--- a/feature/calls/src/main/res/values-pt/strings.xml
+++ b/feature/calls/src/main/res/values-pt/strings.xml
@@ -9,6 +9,7 @@
     <string name="unblockThisCaller" comment="Menu action that removes the block from the selected caller.">Desbloquear este número</string>
     <string name="delete" comment="Menu action that deletes the selected call-log entry.">Excluir</string>
     <string name="anonymous" comment="Fallback caller name when the phone number is withheld.">Anônimo</string>
+    <string name="blocked" comment="Call-log label identifying a call that was blocked.">Bloqueada</string>
     <string name="placeholder_call_log" comment="Empty-state message shown when phone permission is required to display call history.">Ative as permissões do telefone para ver o histórico de chamadas</string>
     <string name="turn_on" comment="Button that opens settings to grant the permission required by the current screen.">Ativar</string>
     <string name="open_contact" comment="Menu action that opens the selected person's contact details.">Abrir contato</string>

--- a/feature/calls/src/main/res/values-ro/strings.xml
+++ b/feature/calls/src/main/res/values-ro/strings.xml
@@ -9,6 +9,7 @@
     <string name="unblockThisCaller" comment="Menu action that removes the block from the selected caller.">Deblochează acest apelant</string>
     <string name="delete" comment="Menu action that deletes the selected call-log entry.">Șterge</string>
     <string name="anonymous" comment="Fallback caller name when the phone number is withheld.">Anonim</string>
+    <string name="blocked" comment="Call-log label identifying a call that was blocked.">Blocat</string>
     <string name="placeholder_call_log" comment="Empty-state message shown when phone permission is required to display call history.">Activează permisiunile pentru telefon pentru a vedea istoricul apelurilor</string>
     <string name="turn_on" comment="Button that opens settings to grant the permission required by the current screen.">Activează</string>
     <string name="open_contact" comment="Menu action that opens the selected person's contact details.">Deschide contactul</string>

--- a/feature/calls/src/main/res/values-zh/strings.xml
+++ b/feature/calls/src/main/res/values-zh/strings.xml
@@ -9,6 +9,7 @@
     <string name="unblockThisCaller" comment="Menu action that removes the block from the selected caller.">取消屏蔽此来电者</string>
     <string name="delete" comment="Menu action that deletes the selected call-log entry.">删除</string>
     <string name="anonymous" comment="Fallback caller name when the phone number is withheld.">匿名</string>
+    <string name="blocked" comment="Call-log label identifying a call that was blocked.">已屏蔽</string>
     <string name="placeholder_call_log" comment="Empty-state message shown when phone permission is required to display call history.">要查看通话记录，请开启电话权限</string>
     <string name="turn_on" comment="Button that opens settings to grant the permission required by the current screen.">开启</string>
     <string name="open_contact" comment="Menu action that opens the selected person's contact details.">打开联系人</string>

--- a/feature/calls/src/main/res/values/strings.xml
+++ b/feature/calls/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="unblockThisCaller" comment="Menu action that removes the block from the selected caller.">Unblock this caller</string>
     <string name="delete" comment="Menu action that deletes the selected call-log entry.">Delete</string>
     <string name="anonymous" comment="Fallback caller name when the phone number is withheld.">Anonymous</string>
+    <string name="blocked" comment="Call-log label identifying a call that was blocked.">Blocked</string>
     <string name="placeholder_call_log" comment="Empty-state message shown when phone permission is required to display call history.">To see your call log, turn on the phone permissions</string>
     <string name="turn_on" comment="Button that opens settings to grant the permission required by the current screen.">Turn on</string>
     <string name="open_contact" comment="Menu action that opens the selected person's contact details.">Open contact</string>


### PR DESCRIPTION
## Summary
- show a Blocked label in call-log subtitles for blocked calls
- retain phone-type labels for other calls
- localize the new label across supported languages

## Testing
- ./gradlew :feature:calls:compileDebugKotlin --rerun-tasks