### PR TITLE
fix(search): remove expanded open contact action

### DIFF
--- a/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/ContactsSearchScreen.kt
+++ b/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/ContactsSearchScreen.kt
@@ -491,14 +491,7 @@ private fun ResultRow(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                     verticalArrangement = Arrangement.spacedBy(1.dp)
                 ) {
-                    if (contact.contactId > 0) {
-                        ResultActionRow(
-                            icon = icons.accountCircle,
-                            label = stringResource(R.string.open_contact),
-                            roundTop = true,
-                            onClick = onOpenContact
-                        )
-                    } else {
+                    if (contact.contactId <= 0) {
                         ResultActionRow(
                             icon = icons.personAdd,
                             label = stringResource(R.string.add_to_a_contact),
@@ -510,6 +503,7 @@ private fun ResultRow(
                     ResultActionRow(
                         icon = icons.message,
                         label = stringResource(R.string.send_message),
+                        roundTop = contact.contactId > 0,
                         onClick = onMessage
                     )
 


### PR DESCRIPTION
## Summary
- remove the redundant Open contact action from expanded contact-search results
- keep opening a contact available from its avatar

## Testing
- ./gradlew :feature:contactsSearch:compileDebugKotlin