### PR TITLE
fix(calls): use person icon for unknown callers

### DIFF
--- a/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppIcons.kt
+++ b/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppIcons.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.outlined.MicOff
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.Pause
 import androidx.compose.material.icons.outlined.People
+import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.PersonAddAlt
 import androidx.compose.material.icons.outlined.Phone
 import androidx.compose.material.icons.outlined.PhonePaused
@@ -106,6 +107,7 @@ data class AppIcons(
     val pause: IconSource,
     val addCall: IconSource,
     val accountCircle: IconSource,
+    val person: IconSource,
     val callReceived: IconSource,
     val callMade: IconSource,
     val callMissed: IconSource,
@@ -147,6 +149,7 @@ val DefaultAppIcons = AppIcons(
     pause = IconSource.Vector(Icons.Outlined.Pause),
     addCall = IconSource.Vector(Icons.Outlined.AddIcCall),
     accountCircle = IconSource.Vector(Icons.Filled.AccountCircle),
+    person = IconSource.Vector(Icons.Outlined.Person),
     callReceived = IconSource.Vector(Icons.AutoMirrored.Outlined.CallReceived),
     callMade = IconSource.Vector(Icons.AutoMirrored.Outlined.CallMade),
     callMissed = IconSource.Vector(Icons.AutoMirrored.Outlined.CallMissed),

--- a/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/CallDetailScreen.kt
+++ b/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/CallDetailScreen.kt
@@ -235,7 +235,7 @@ private fun TopBar(
                         fallbackIcon = if (call.isVoicemailNumber) {
                             LocalAppIcons.current.voicemail
                         } else {
-                            LocalAppIcons.current.accountCircle
+                            LocalAppIcons.current.person
                         },
                         avatarIcon = if (isNumberBlocked) LocalAppIcons.current.block else null,
                         contentDescription = if (call.isVoicemailNumber) {

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
@@ -590,7 +590,7 @@ private fun CallRow(
                     fallbackIcon = if (call.isVoicemailNumber) {
                         icons.voicemail
                     } else {
-                        icons.accountCircle
+                        icons.person
                     },
                     avatarIcon = if (isNumberBlocked) icons.block else null,
                     contentDescription = if (call.isVoicemailNumber) {


### PR DESCRIPTION
## Summary
- use the outlined person icon for non-contact call-log entries
- apply the same fallback in the call-history header

## Testing
- ./gradlew :core:common:compileDebugKotlin :feature:calls:compileDebugKotlin :feature:callDetail:compileDebugKotlin