### PR TITLE
feat: add icons to AppIcons

### DIFF
--- a/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppIcons.kt
+++ b/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppIcons.kt
@@ -100,6 +100,7 @@ fun AppIcon(
 data class AppIcons(
     val hangup: IconSource,
     val dialpad: IconSource,
+    val dialpadActive: IconSource = dialpad,
     val mute: IconSource,
     val speaker: IconSource,
     val more: IconSource,

--- a/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppIcons.kt
+++ b/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppIcons.kt
@@ -112,6 +112,7 @@ data class AppIcons(
     val voicemail: IconSource,
     val voicemailSelected: IconSource = voicemail,
     val block: IconSource,
+    val blockCall: IconSource = block,
     val phone: IconSource,
     val message: IconSource,
     val personAdd: IconSource,

--- a/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/CallDetailScreen.kt
+++ b/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/CallDetailScreen.kt
@@ -412,7 +412,7 @@ private fun CallRow(
                 CallType.OUTGOING -> icons.callMade
                 CallType.MISSED, CallType.REJECTED -> icons.callMissed
                 CallType.VOICEMAIL -> icons.voicemail
-                CallType.BLOCKED -> icons.block
+                CallType.BLOCKED -> icons.blockCall
             }, contentDescription = null, tint = subtitleColor,
             modifier = Modifier.size(24.dp)
         )

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
@@ -646,7 +646,7 @@ private fun CallRow(
                                 CallType.OUTGOING -> icons.callMade
                                 CallType.MISSED, CallType.REJECTED -> icons.callMissed
                                 CallType.VOICEMAIL -> icons.voicemail
-                                CallType.BLOCKED -> icons.block
+                                CallType.BLOCKED -> icons.blockCall
                             },
                             contentDescription = null,
                             tint = subtitleColor,

--- a/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
+++ b/feature/calls/src/main/java/dev/alenajam/opendialer/feature/calls/CallsScreen.kt
@@ -679,15 +679,28 @@ private fun CallRow(
 
             AnimatedVisibility(visible = isOpen) {
                 Column(
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                    verticalArrangement = Arrangement.spacedBy(1.dp),
-                ) {
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(1.dp),
+            ) {
+                    if (!call.isAnonymous() && isNumberBlocked) {
+                        CallRowButton(
+                            label = stringResource(R.string.unblockThisCaller),
+                            icon = icons.block,
+                            roundTop = true,
+                            onClick = {
+                                unblockNumber()
+                                isNumberBlocked = false
+                                onBlockStatusChanged(false)
+                            },
+                        )
+                    }
+
                     if (!call.isAnonymous()) {
                         if (!call.isContactSaved()) {
                             CallRowButton(
                                 label = stringResource(R.string.add_to_a_contact),
                                 icon = icons.personAdd,
-                                roundTop = true,
+                                roundTop = !isNumberBlocked,
                                 onClick = addContact
                             )
                         }
@@ -695,7 +708,7 @@ private fun CallRow(
                         CallRowButton(
                             label = stringResource(R.string.send_message),
                             icon = icons.message,
-                            roundTop = call.isContactSaved(),
+                            roundTop = call.isContactSaved() && !isNumberBlocked,
                             onClick = sendMessage,
                         )
                     }
@@ -704,22 +717,9 @@ private fun CallRow(
                         label = stringResource(R.string.history),
                         icon = icons.history,
                         roundTop = call.isAnonymous(),
-                        roundBottom = call.isAnonymous(),
+                        roundBottom = true,
                         onClick = openHistory,
                     )
-
-                    if (!call.isAnonymous() && isNumberBlocked) {
-                        CallRowButton(
-                            label = stringResource(R.string.unblockThisCaller),
-                            icon = icons.block,
-                            roundBottom = true,
-                            onClick = {
-                                unblockNumber()
-                                isNumberBlocked = false
-                                onBlockStatusChanged(false)
-                            },
-                        )
-                    }
                 }
             }
         }

--- a/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/Footer.kt
+++ b/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/Footer.kt
@@ -230,7 +230,11 @@ fun InCallControls(
                     .padding(bottom = 16.dp, top = 16.dp)
             ) {
                 CallButton(
-                    icon = icons.dialpad,
+                    icon = if (openSection.value == OpenSection.DIALPAD) {
+                        icons.dialpadActive
+                    } else {
+                        icons.dialpad
+                    },
                     label = stringResource(R.string.control_dialpad),
                     isActive = openSection.value == OpenSection.DIALPAD,
                     enabled = controlsEnabled,


### PR DESCRIPTION
## Summary
- add a dedicated blocked-call icon source
- use it for blocked call rows while preserving the existing blocked-contact icon

## Verification
- ./gradlew :app:compileDebugKotlin (from Monster Dialer)