### PR TITLE
fix: replace account circle icon

### DIFF
--- a/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppIcons.kt
+++ b/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppIcons.kt
@@ -13,7 +13,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.AccessTimeFilled
-import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Voicemail
@@ -107,7 +106,6 @@ data class AppIcons(
     val more: IconSource,
     val pause: IconSource,
     val addCall: IconSource,
-    val accountCircle: IconSource,
     val person: IconSource,
     val callReceived: IconSource,
     val callMade: IconSource,
@@ -150,7 +148,6 @@ val DefaultAppIcons = AppIcons(
     more = IconSource.Vector(Icons.Outlined.MoreVert),
     pause = IconSource.Vector(Icons.Outlined.Pause),
     addCall = IconSource.Vector(Icons.Outlined.AddIcCall),
-    accountCircle = IconSource.Vector(Icons.Filled.AccountCircle),
     person = IconSource.Vector(Icons.Outlined.Person),
     callReceived = IconSource.Vector(Icons.AutoMirrored.Outlined.CallReceived),
     callMade = IconSource.Vector(Icons.AutoMirrored.Outlined.CallMade),

--- a/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/ContactAvatar.kt
+++ b/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/ContactAvatar.kt
@@ -25,7 +25,7 @@ fun ContactAvatar(
     modifier: Modifier = Modifier,
     contentDescription: String? = null,
     colorKey: String = contactAvatarColorKey(name),
-    fallbackIcon: IconSource = LocalAppIcons.current.accountCircle,
+    fallbackIcon: IconSource = LocalAppIcons.current.person,
     fallbackIconModifier: Modifier = Modifier.size(24.dp),
     avatarIcon: IconSource? = null,
     initialTextStyle: TextStyle = MaterialTheme.typography.titleLarge

--- a/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/ContactsSearchScreen.kt
+++ b/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/ContactsSearchScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Backspace
-import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.material3.Button

--- a/feature/voicemail/src/main/java/dev/alenajam/opendialer/feature/voicemail/VoicemailScreen.kt
+++ b/feature/voicemail/src/main/java/dev/alenajam/opendialer/feature/voicemail/VoicemailScreen.kt
@@ -167,7 +167,7 @@ private fun VoicemailRow(
             modifier = Modifier.padding(16.dp),
         ) {
             AppIcon(
-                icon = LocalAppIcons.current.accountCircle,
+                icon = LocalAppIcons.current.person,
                 contentDescription = null,
                 modifier = Modifier.size(32.dp),
             )


### PR DESCRIPTION
## Summary
- remove the account-circle icon from the shared icon catalog
- use the person icon for contact avatars and voicemail rows

## Verification
- ./gradlew :core:common:compileDebugKotlin :feature:voicemail:compileDebugKotlin :feature:contactsSearch:compileDebugKotlin