### PR TITLE
fix: refresh call detail history

### DIFF
--- a/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsRepositoryImpl.kt
+++ b/data/calls/src/main/java/dev/alenajam/opendialer/data/calls/CallsRepositoryImpl.kt
@@ -48,7 +48,29 @@ class CallsRepositoryImpl @Inject constructor(
 
     override suspend fun getCallByIds(
         ids: List<Int>
-    ): Either<Failure, List<DialerCallEntity>> {
+    ): Either<Failure, List<DialerCallEntity>> = getCallDataByIds(ids)
+
+    fun observeCallByIds(ids: List<Int>): Flow<Either<Failure, List<DialerCallEntity>>> =
+        callbackFlow {
+            fun emitCallData() {
+                trySend(getCallDataByIds(ids))
+            }
+
+            val observer = object : ContentObserver(null) {
+                override fun onChange(selfChange: Boolean) {
+                    emitCallData()
+                }
+            }
+
+            app.contentResolver.registerContentObserver(CallsData.getUri(app), true, observer)
+            emitCallData()
+
+            awaitClose {
+                app.contentResolver.unregisterContentObserver(observer)
+            }
+        }
+
+    private fun getCallDataByIds(ids: List<Int>): Either<Failure, List<DialerCallEntity>> {
         val selectedCalls = CallDetailData.getCursor(app.contentResolver, ids)?.use { cursor ->
             CallDetailData.getData(
                 cursor = cursor,

--- a/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/DialerViewModel.kt
+++ b/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/DialerViewModel.kt
@@ -45,15 +45,17 @@ class DialerViewModel
     private val callDetail = savedStateHandle.toRoute<CallDetailRoute>()
 
     init {
-        getCallByIds(callDetail.callIds)
+        observeCallByIds(callDetail.callIds)
     }
 
-    fun getCallByIds(ids: List<Int>) {
+    private fun observeCallByIds(ids: List<Int>) {
         viewModelScope.launch {
-            callsRepositoryImpl.getCallByIds(ids).fold(
-                { /* TODO handle failure */ },
-                { call -> _call.postValue(DialerCall.mapList(call).first()) }
-            )
+            callsRepositoryImpl.observeCallByIds(ids).collect { result ->
+                result.fold(
+                    { /* TODO handle failure */ },
+                    { call -> _call.postValue(DialerCall.mapList(call).first()) }
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- observe call-log changes while a call-detail screen is open
- refresh the displayed contact history when the call log changes

## Verification
- ./gradlew :data:calls:compileDebugKotlin :feature:callDetail:compileDebugKotlin