### PR TITLE
fix(contacts): clamp stale dialpad selections

### DIFF
--- a/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/ContactsSearchScreen.kt
+++ b/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/ContactsSearchScreen.kt
@@ -630,13 +630,13 @@ private fun Footer(
     }
 
     fun handleButtonClick(digit: Char) {
-        val newQuery = query.replaceRange(selection.start, selection.end, digit.toString())
-        onQueryChange(newQuery, TextRange(selection.start + 1))
+        val edit = replaceDialpadSelection(query, selection, digit.toString())
+        onQueryChange(edit.text, edit.selection)
     }
 
     fun insertDialModifier(modifier: Char) {
-        val newQuery = query.replaceRange(selection.start, selection.end, modifier.toString())
-        onQueryChange(newQuery, TextRange(selection.start + 1))
+        val edit = replaceDialpadSelection(query, selection, modifier.toString())
+        onQueryChange(edit.text, edit.selection)
         overflowExpanded = false
     }
 
@@ -705,21 +705,8 @@ private fun Footer(
                         .combinedClickable(
                             enabled = isBackspaceEnabled,
                             onClick = {
-                                if (selection.end > selection.start) {
-                                    onQueryChange(
-                                        query.replaceRange(selection.start, selection.end, ""),
-                                        TextRange(selection.start)
-                                    )
-                                } else if (selection.start > 0) {
-                                    onQueryChange(
-                                        query.replaceRange(
-                                            selection.start - 1,
-                                            selection.end,
-                                            ""
-                                        ),
-                                        TextRange(selection.start - 1)
-                                    )
-                                }
+                                val edit = deleteDialpadSelection(query, selection)
+                                onQueryChange(edit.text, edit.selection)
                             },
                             onLongClick = {
                                 onQueryChange("", TextRange.Zero)

--- a/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/DialpadTextEditing.kt
+++ b/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/DialpadTextEditing.kt
@@ -1,0 +1,36 @@
+package dev.alenajam.opendialer.feature.contactsSearch
+
+import androidx.compose.ui.text.TextRange
+
+internal data class DialpadTextEdit(
+    val text: String,
+    val selection: TextRange
+)
+
+internal fun replaceDialpadSelection(
+    text: String,
+    selection: TextRange,
+    replacement: String
+): DialpadTextEdit {
+    val start = minOf(selection.start, selection.end).coerceIn(0, text.length)
+    val end = maxOf(selection.start, selection.end).coerceIn(start, text.length)
+
+    return DialpadTextEdit(
+        text = text.replaceRange(start, end, replacement),
+        selection = TextRange(start + replacement.length)
+    )
+}
+
+internal fun deleteDialpadSelection(
+    text: String,
+    selection: TextRange
+): DialpadTextEdit {
+    val start = minOf(selection.start, selection.end).coerceIn(0, text.length)
+    val end = maxOf(selection.start, selection.end).coerceIn(start, text.length)
+    val deleteStart = if (start == end) (start - 1).coerceAtLeast(0) else start
+
+    return DialpadTextEdit(
+        text = text.replaceRange(deleteStart, end, ""),
+        selection = TextRange(deleteStart)
+    )
+}

--- a/feature/contactsSearch/src/test/java/dev/alenajam/opendialer/feature/contactsSearch/DialpadTextEditingTest.kt
+++ b/feature/contactsSearch/src/test/java/dev/alenajam/opendialer/feature/contactsSearch/DialpadTextEditingTest.kt
@@ -1,0 +1,31 @@
+package dev.alenajam.opendialer.feature.contactsSearch
+
+import androidx.compose.ui.text.TextRange
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DialpadTextEditingTest {
+    @Test
+    fun `replacement clamps stale selection to current text`() {
+        val result = replaceDialpadSelection("1", TextRange(0, 2), "2")
+
+        assertEquals("2", result.text)
+        assertEquals(TextRange(1), result.selection)
+    }
+
+    @Test
+    fun `replacement clamps a stale cursor to the end of current text`() {
+        val result = replaceDialpadSelection("1", TextRange(2), "2")
+
+        assertEquals("12", result.text)
+        assertEquals(TextRange(2), result.selection)
+    }
+
+    @Test
+    fun `backspace clamps stale selection to current text`() {
+        val result = deleteDialpadSelection("1", TextRange(0, 2))
+
+        assertEquals("", result.text)
+        assertEquals(TextRange.Zero, result.selection)
+    }
+}


### PR DESCRIPTION
## Summary
- clamp dialpad selection ranges to the current query length before editing
- safely handle stale selections for digit entry, modifiers, and backspace
- add regression coverage for a one-character query with a stale end index

## Testing
- ./gradlew :feature:contactsSearch:testDebugUnitTest