### PR TITLE
fix(incall): use configurable conference icons

### DIFF
--- a/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppIcons.kt
+++ b/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppIcons.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.outlined.AccessTime
 import androidx.compose.material.icons.automirrored.outlined.CallMade
 import androidx.compose.material.icons.automirrored.outlined.CallMissed
 import androidx.compose.material.icons.automirrored.outlined.CallReceived
+import androidx.compose.material.icons.automirrored.outlined.CallSplit
 import androidx.compose.material.icons.automirrored.outlined.Message
 import androidx.compose.material.icons.automirrored.outlined.VolumeUp
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -120,6 +121,7 @@ data class AppIcons(
     val personAddInContactsList: IconSource = personAdd,
     val history: IconSource,
     val merge: IconSource,
+    val split: IconSource = IconSource.Vector(Icons.AutoMirrored.Outlined.CallSplit),
     val swapCalls: IconSource,
     val phonePaused: IconSource,
     val recents: IconSource,

--- a/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppIcons.kt
+++ b/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppIcons.kt
@@ -108,6 +108,7 @@ data class AppIcons(
     val pause: IconSource,
     val addCall: IconSource,
     val person: IconSource,
+    val conference: IconSource = IconSource.Vector(Icons.Outlined.People),
     val callReceived: IconSource,
     val callMade: IconSource,
     val callMissed: IconSource,

--- a/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/Footer.kt
+++ b/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/Footer.kt
@@ -153,7 +153,7 @@ fun InCallControls(
                         if (canMerge) add(MoreAction(icons.merge, stringResource(R.string.conference_merge), onMerge, enabled = controlsEnabled))
                         if (canSwap) add(MoreAction(icons.swapCalls, stringResource(R.string.conference_swap), onSwap, enabled = controlsEnabled))
                         if (canManageConference) {
-                            add(MoreAction(icons.more, stringResource(R.string.conference_manage), onManageConference, enabled = controlsEnabled))
+                            add(MoreAction(icons.person, stringResource(R.string.conference_manage), onManageConference, enabled = controlsEnabled))
                         }
                     }
 

--- a/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/InCallDetails.kt
+++ b/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/InCallDetails.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.alenajam.opendialer.core.common.CommonUtils
 import dev.alenajam.opendialer.core.common.ui.ContactAvatar
+import dev.alenajam.opendialer.core.common.ui.LocalAppIcons
 import dev.alenajam.opendialer.core.common.ui.contactAvatarColorKey
 import dev.alenajam.opendialer.feature.inCall.R
 
@@ -27,10 +28,12 @@ fun InCallDetails(
     status: CallStatus,
     durationMillis: Long,
     callerImageUri: String? = null,
+    isConference: Boolean = false,
     modifier: Modifier = Modifier,
     showCallerImage: Boolean = true,
     useCompactCallerText: Boolean = false,
 ) {
+    val icons = LocalAppIcons.current
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
@@ -88,6 +91,7 @@ fun InCallDetails(
                 photoUri = callerImageUri,
                 colorKey = contactAvatarColorKey(callerName, callerNumber),
                 fallbackIconModifier = Modifier.size(72.dp),
+                avatarIcon = if (isConference) icons.conference else null,
                 initialTextStyle = MaterialTheme.typography.displayLarge,
                 modifier = Modifier.size(176.dp)
             )

--- a/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/InCallScreen.kt
+++ b/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/InCallScreen.kt
@@ -83,26 +83,29 @@ internal fun InCallScreen(
             color = MaterialTheme.colorScheme.background
         ) {
             Box(modifier = Modifier.fillMaxSize()) {
-            Column(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    InCallDetails(
+                        callerName = uiState.callerName,
+                        callerNumber = uiState.callerNumber,
+                        callerNumberLabel = uiState.callerNumberLabel,
+                        status = uiState.status,
+                        durationMillis = durationMillis,
+                        callerImageUri = uiState.callerImageUri,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .statusBarsPadding()
+                            .padding(top = 32.dp)
+                    )
+                }
+
                 if (hasSecondaryCall && secondaryCallerName != null && !uiState.isIncoming) {
                     SecondaryCallBanner(
                         callerName = secondaryCallerName,
-                        modifier = Modifier.statusBarsPadding()
+                        modifier = Modifier
+                            .statusBarsPadding()
+                            .align(Alignment.TopCenter)
                     )
                 }
-                InCallDetails(
-                    callerName = uiState.callerName,
-                    callerNumber = uiState.callerNumber,
-                    callerNumberLabel = uiState.callerNumberLabel,
-                    status = uiState.status,
-                    durationMillis = durationMillis,
-                    callerImageUri = uiState.callerImageUri,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .statusBarsPadding()
-                        .padding(top = 32.dp)
-                )
-            }
 
             if (uiState.isIncoming) {
                 IncomingCallControls(

--- a/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/InCallScreen.kt
+++ b/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/InCallScreen.kt
@@ -91,6 +91,7 @@ internal fun InCallScreen(
                         status = uiState.status,
                         durationMillis = durationMillis,
                         callerImageUri = uiState.callerImageUri,
+                        isConference = canManageConference,
                         modifier = Modifier
                             .fillMaxWidth()
                             .statusBarsPadding()

--- a/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/ManageConferenceSheet.kt
+++ b/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/ManageConferenceSheet.kt
@@ -126,7 +126,7 @@ private fun ConferenceParticipantRow(
                 ) {
                     Box(contentAlignment = Alignment.Center) {
                         AppIcon(
-                            icon = icons.merge,
+                            icon = icons.split,
                             contentDescription = stringResource(R.string.action_split),
                             modifier = Modifier.size(24.dp),
                             tint = MaterialTheme.colorScheme.onSurfaceVariant

--- a/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/SecondaryCallBanner.kt
+++ b/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/SecondaryCallBanner.kt
@@ -38,7 +38,7 @@ fun SecondaryCallBanner(
                 .padding(horizontal = 16.dp, vertical = 12.dp)
         ) {
             AppIcon(
-                icon = icons.phonePaused,
+                icon = icons.pause,
                 contentDescription = null,
                 tint = Color.White,
                 modifier = Modifier.size(20.dp)

--- a/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/SecondaryCallBanner.kt
+++ b/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/SecondaryCallBanner.kt
@@ -38,7 +38,7 @@ fun SecondaryCallBanner(
                 .padding(horizontal = 16.dp, vertical = 12.dp)
         ) {
             AppIcon(
-                icon = icons.pause,
+                icon = icons.phonePaused,
                 contentDescription = null,
                 tint = Color.White,
                 modifier = Modifier.size(20.dp)


### PR DESCRIPTION
## Summary\n- use configurable hold, manage, and participant hangup icons\n- add a shared default call-split icon\n- use the split icon in conference participant rows\n\n## Verification\n- ./gradlew :feature:inCall:compileDebugKotlin :app:compileDebugKotlin