### PR TITLE
fix(contactsSearch): prevent dialpad text wrapping

### DIFF
--- a/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/ContactsSearchScreen.kt
+++ b/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/ContactsSearchScreen.kt
@@ -681,6 +681,7 @@ private fun Footer(
                     modifier = Modifier.weight(1f),
                     value = TextFieldValue(text = query, selection = selection),
                     onValueChange = { onQueryChange(it.text, it.selection) },
+                    singleLine = true,
                     textStyle = LocalTextStyle.current.copy(
                         textAlign = TextAlign.Center,
                         fontSize = MaterialTheme.typography.headlineMedium.fontSize


### PR DESCRIPTION
Ensures the dialed number stays on a single line and scrolls horizontally when it overflows, rather than wrapping to a second line.