### PR TITLE
feat: add support for actions in SettingsSubpage

### DIFF
--- a/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsSubpage.kt
+++ b/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsSubpage.kt
@@ -1,6 +1,7 @@
 package dev.alenajam.opendialer.feature.settings
 
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -21,6 +22,7 @@ data class SettingsSubpage(
     val description: String? = null,
     val subtitle: String? = null,
     val content: @Composable ColumnScope.() -> Unit,
+    val actions: @Composable RowScope.() -> Unit = {},
     val isScrollable: Boolean = true,
     val topContentPadding: Dp = 16.dp,
     val destinations: List<SettingsSubpageDestination> = emptyList()

--- a/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsSubpageScreen.kt
+++ b/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsSubpageScreen.kt
@@ -32,34 +32,36 @@ fun SettingsSubpageScreen(
     onNavigateBack: () -> Unit,
     onNavigateToDestination: (Int) -> Unit
 ) {
-    Scaffold(topBar = {
-        TopAppBar(title = {
-            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                Text(page.title)
-                page.subtitle?.let { subtitle ->
-                    Text(
-                        subtitle,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+    CompositionLocalProvider(
+        LocalSettingsSubpageNavigator provides SettingsSubpageNavigator(onNavigateToDestination)
+    ) {
+        Scaffold(topBar = {
+            TopAppBar(title = {
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text(page.title)
+                    page.subtitle?.let { subtitle ->
+                        Text(
+                            subtitle,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                 }
+            }, navigationIcon = {
+                IconButton(onClick = onNavigateBack) {
+                    AppIcon(LocalAppIcons.current.arrowLeft, contentDescription = null)
+                }
+            }, actions = page.actions)
+        }) { padding ->
+            val contentModifier = Modifier
+                .padding(padding.copy(top = padding.calculateTopPadding() + page.topContentPadding, start = 16.dp, end = 16.dp))
+                .fillMaxSize()
+                .let { modifier ->
+                    if (page.isScrollable) modifier.verticalScroll(rememberScrollState()) else modifier
+                }
+            Column(modifier = contentModifier) {
+                page.content(this@Column)
             }
-        }, navigationIcon = {
-            IconButton(onClick = onNavigateBack) {
-                AppIcon(LocalAppIcons.current.arrowLeft, contentDescription = null)
-            }
-        })
-    }) { padding ->
-        val contentModifier = Modifier
-            .padding(padding.copy(top = padding.calculateTopPadding() + page.topContentPadding, start = 16.dp, end = 16.dp))
-            .fillMaxSize()
-            .let { modifier ->
-                if (page.isScrollable) modifier.verticalScroll(rememberScrollState()) else modifier
-            }
-        Column(modifier = contentModifier) {
-            CompositionLocalProvider(
-                LocalSettingsSubpageNavigator provides SettingsSubpageNavigator(onNavigateToDestination)
-            ) { page.content(this@Column) }
         }
     }
 }


### PR DESCRIPTION
This PR adds an 'actions' parameter to SettingsSubpage, allowing custom top bar buttons (like 'Add') to be injected from consumer apps.