### PR TITLE
fix(shell): clear active home search on back

### DIFF
--- a/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/HomeScreen.kt
+++ b/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/HomeScreen.kt
@@ -1,5 +1,6 @@
 package dev.alenajam.opendialer.feature.appShell
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -52,6 +53,11 @@ internal fun HomeScreen(
 ) {
     var currentTab by remember { mutableStateOf(HomeTab.CALLS) }
     var searchQuery by remember { mutableStateOf("") }
+    val isSearchActive = searchQuery.isNotEmpty()
+
+    BackHandler(enabled = isSearchActive) {
+        searchQuery = ""
+    }
 
     Scaffold(
         topBar = {
@@ -65,16 +71,24 @@ internal fun HomeScreen(
                         onExpandedChange = {},
                         placeholder = { Text(stringResource(R.string.search_contacts)) },
                         leadingIcon = {
-                            IconButton(onClick = {}) {
+                            IconButton(onClick = { if (isSearchActive) searchQuery = "" }) {
                                 AppIcon(
-                                    LocalAppIcons.current.search,
-                                    contentDescription = null,
+                                    if (isSearchActive) {
+                                        LocalAppIcons.current.arrowLeft
+                                    } else {
+                                        LocalAppIcons.current.search
+                                    },
+                                    contentDescription = if (isSearchActive) {
+                                        stringResource(R.string.clear_search)
+                                    } else {
+                                        null
+                                    },
                                     modifier = Modifier.size(24.dp)
                                 )
                             }
                         },
                         trailingIcon = {
-                            if (searchQuery.isNotEmpty()) {
+                            if (isSearchActive) {
                                 IconButton(onClick = { searchQuery = "" }) {
                                     AppIcon(
                                         LocalAppIcons.current.close,


### PR DESCRIPTION
## Summary
- clear a non-empty home search query when the system Back button is pressed
- show a back arrow in place of the search icon while a query is active
- make the back arrow clear the query and expose an accessibility label

## Testing
- ./gradlew :feature:appShell:compileDebugKotlin --rerun-tasks