### PR TITLE
feat: expose stable in-call identifier

### DIFF
--- a/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/InCallUiState.kt
+++ b/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/InCallUiState.kt
@@ -29,6 +29,7 @@ enum class CallStatus {
 }
 
 data class InCallUiState(
+    val callId: String = "",
     val status: CallStatus = CallStatus.IDLE,
     val isHolding: Boolean = false,
     val isSpeaker: Boolean = false,

--- a/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/InCallViewModel.kt
+++ b/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/InCallViewModel.kt
@@ -2,6 +2,7 @@ package dev.alenajam.opendialer.feature.inCall.ui
 
 import android.app.Activity
 import android.content.Intent
+import android.os.Build
 import android.telecom.Call
 import android.telecom.CallAudioState
 import androidx.lifecycle.ViewModel
@@ -44,6 +45,7 @@ class InCallViewModel @Inject constructor(
         val conferenceChildren = primary?.call?.children.orEmpty().toSet()
 
         InCallUiState(
+            callId = primary?.stableId().orEmpty(),
             status = CallStatus.fromTelecomState(primary?.state),
             isHolding = primary?.state == Call.STATE_HOLDING,
             isSpeaker = audio?.route == CallAudioState.ROUTE_SPEAKER,
@@ -148,6 +150,13 @@ class InCallViewModel @Inject constructor(
     fun turnMute() = callManager.toggleMute()
 
     fun swap() = callManager.swap()
+
+    private fun OngoingCall.stableId(): String =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            call.details.creationTimeMillis.toString()
+        } else {
+            sequence.toString()
+        }
 
     fun addCall(activity: Activity) = activity.startActivity(
         Intent(Intent.ACTION_DIAL).putExtra(


### PR DESCRIPTION
Expose a stable Telecom-derived call identifier in the in-call UI state. This lets clients retain call-specific state across activity or process recreation without confusing a later call to the same contact.