### PR TITLE
chore: support icon designer credits

### DIFF
--- a/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppIcons.kt
+++ b/core/common/src/main/java/dev/alenajam/opendialer/core/common/ui/AppIcons.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.automirrored.outlined.CallMade
 import androidx.compose.material.icons.automirrored.outlined.CallMissed
 import androidx.compose.material.icons.automirrored.outlined.CallReceived
 import androidx.compose.material.icons.automirrored.outlined.CallSplit
+import androidx.compose.material.icons.automirrored.outlined.Backspace
 import androidx.compose.material.icons.automirrored.outlined.Message
 import androidx.compose.material.icons.automirrored.outlined.VolumeUp
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -105,6 +106,7 @@ data class AppIcons(
     val mute: IconSource,
     val speaker: IconSource,
     val more: IconSource,
+    val backspace: IconSource = IconSource.Vector(Icons.AutoMirrored.Outlined.Backspace),
     val pause: IconSource,
     val addCall: IconSource,
     val person: IconSource,

--- a/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/DialerApp.kt
+++ b/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/DialerApp.kt
@@ -159,7 +159,7 @@ fun DialerApp(
                         onOpenSettings = { navController.navigate(SettingsRoute) },
                         onOpenAbout = { navController.navigate(AboutRoute) },
                         onAddFavorite = { navController.navigate(AddFavoriteRoute) },
-                        onOpenSettingsSubpage = { navController.navigate(SettingsSubpageRoute(it)) },
+                        onOpenSettingsSubpage = { index, payload -> navController.navigate(SettingsSubpageRoute(index, payload)) },
                         onOpenVoicemail = { navController.navigate(VoicemailRoute) },
                         configuration = homeScreenConfiguration,
                     )
@@ -200,7 +200,7 @@ fun DialerApp(
                         onOpenQuickResponses = { navController.navigate(QuickResponsesRoute) },
                         onOpenDisplayOptions = { navController.navigate(DisplayOptionsRoute) },
                         subpages = settingsSubpages,
-                        onOpenSubpage = { navController.navigate(SettingsSubpageRoute(it)) }
+                        onOpenSubpage = { index, payload -> navController.navigate(SettingsSubpageRoute(index, payload)) }
                     )
                 }
                 composable<AboutRoute> {
@@ -217,6 +217,7 @@ fun DialerApp(
                     settingsSubpages.getOrNull(route.index)?.let { page ->
                         SettingsSubpageScreen(
                             page = page,
+                            payload = route.payload,
                             onNavigateBack = { navController.popBackStack() },
                             onNavigateToDestination = { destinationIndex, payload ->
                                 navController.navigate(SettingsSubpageDestinationRoute(route.index, destinationIndex, payload))

--- a/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/HomeScreen.kt
+++ b/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/HomeScreen.kt
@@ -6,13 +6,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -117,7 +114,7 @@ internal fun HomeScreen(
                                 Box {
                                     var expanded by remember { mutableStateOf(false) }
                                     IconButton(onClick = { expanded = true }) {
-                                        Icon(Icons.Default.MoreVert, contentDescription = null)
+                                        AppIcon(LocalAppIcons.current.more, contentDescription = null)
                                     }
                                     DropdownMenu(
                                         expanded = expanded,

--- a/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/HomeScreen.kt
+++ b/feature/appShell/src/main/java/dev/alenajam/opendialer/feature/appShell/HomeScreen.kt
@@ -31,6 +31,7 @@ import dev.alenajam.opendialer.core.common.ui.AppIcon
 import dev.alenajam.opendialer.core.common.ui.LocalAppIcons
 import dev.alenajam.opendialer.feature.calls.CallsScreen
 import dev.alenajam.opendialer.feature.contacts.ContactsScreen
+import dev.alenajam.opendialer.feature.contacts.ContactRowTrailingAction
 import dev.alenajam.opendialer.feature.contactsSearch.ContactsTextSearchResults
 import dev.alenajam.opendialer.feature.voicemail.VoicemailScreen
 
@@ -44,13 +45,14 @@ enum class HomeTab {
 data class HomeNavigationItem(
     val label: @Composable () -> Unit,
     val icon: @Composable (selected: Boolean) -> Unit,
-    val content: @Composable (onOpenSettingsSubpage: (Int) -> Unit) -> Unit,
+    val content: @Composable (onOpenSettingsSubpage: (Int, String?) -> Unit) -> Unit,
 )
 
 data class HomeScreenConfiguration(
     val showVoicemailInNavigation: Boolean = true,
     val showVoicemailInOverflow: Boolean = false,
     val customNavigationItem: HomeNavigationItem? = null,
+    val contactRowTrailingAction: ContactRowTrailingAction? = null,
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -61,7 +63,7 @@ internal fun HomeScreen(
     onOpenSettings: () -> Unit,
     onOpenAbout: () -> Unit,
     onAddFavorite: () -> Unit = {},
-    onOpenSettingsSubpage: (Int) -> Unit = {},
+    onOpenSettingsSubpage: (Int, String?) -> Unit = { _, _ -> },
     onOpenVoicemail: () -> Unit = {},
     configuration: HomeScreenConfiguration = HomeScreenConfiguration(),
 ) {
@@ -223,7 +225,11 @@ internal fun HomeScreen(
                         onAddFavorite = onAddFavorite,
                         onEditNumberBeforeCall = onOpenDialpad,
                     )
-                    HomeTab.CONTACTS -> ContactsScreen(onOpenHistory = onOpenHistory)
+                    HomeTab.CONTACTS -> ContactsScreen(
+                        onOpenHistory = onOpenHistory,
+                        contactRowTrailingAction = configuration.contactRowTrailingAction,
+                        onOpenSettingsSubpage = onOpenSettingsSubpage,
+                    )
                     HomeTab.VOICEMAIL -> VoicemailScreen()
                     HomeTab.CUSTOM -> configuration.customNavigationItem?.content(onOpenSettingsSubpage)
                 }

--- a/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/CallDetailScreen.kt
+++ b/feature/callDetail/src/main/java/dev/alenajam/opendialer/feature/callDetail/CallDetailScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material.icons.outlined.CallMade
 import androidx.compose.material.icons.outlined.CallMissed
 import androidx.compose.material.icons.outlined.CallReceived
 import androidx.compose.material.icons.outlined.Message
-import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.Voicemail
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.BottomAppBarDefaults
@@ -26,7 +25,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.FloatingActionButtonDefaults
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.DropdownMenu
@@ -271,7 +269,7 @@ private fun TopBar(
         actions = {
             if (canBlock || canUnblock) {
                 IconButton(onClick = { menuExpanded = true }) {
-                    Icon(Icons.Outlined.MoreVert, contentDescription = stringResource(R.string.more_options))
+                    AppIcon(LocalAppIcons.current.more, contentDescription = stringResource(R.string.more_options))
                 }
                 DropdownMenu(
                     expanded = menuExpanded,

--- a/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/ContactsScreen.kt
+++ b/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/ContactsScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -23,6 +24,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -40,12 +42,21 @@ import dev.alenajam.opendialer.core.common.CommonUtils
 import dev.alenajam.opendialer.core.common.PermissionUtils
 import dev.alenajam.opendialer.core.common.ui.LocalAppIcons
 import dev.alenajam.opendialer.data.contacts.DialerContactSummary
+import kotlinx.coroutines.launch
+
+data class ContactRowTrailingAction(
+    val settingsSubpageIndex: Int,
+    val onClick: suspend (DialerContactSummary) -> Unit,
+    val content: @Composable () -> Unit,
+)
 
 @Composable
 fun ContactsScreen(
     viewModel: ContactsViewModel = hiltViewModel(),
     searchQuery: String = "",
     @Suppress("UNUSED_PARAMETER") onOpenHistory: (callIds: List<Int>) -> Unit = {},
+    contactRowTrailingAction: ContactRowTrailingAction? = null,
+    onOpenSettingsSubpage: (Int, String?) -> Unit = { _, _ -> },
 ) {
     val requestPermissions =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
@@ -58,6 +69,7 @@ fun ContactsScreen(
     val profileContact = viewModel.profileContact.collectAsStateWithLifecycle()
     val hasPermission = viewModel.hasRuntimePermission.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
     val filteredContacts = if (searchQuery.isBlank()) {
         contacts.value
     } else {
@@ -100,7 +112,9 @@ fun ContactsScreen(
             return@Surface
         }
 
-        LazyColumn {
+        LazyColumn(
+            contentPadding = PaddingValues(bottom = 88.dp),
+        ) {
             if (searchQuery.isBlank()) {
                 item(key = "new-contact") {
                     Button(
@@ -143,6 +157,13 @@ fun ContactsScreen(
                             roundTop = item.isFirstInSection,
                             roundBottom = item.isLastInSection,
                             onOpenContact = { viewModel.openContact(item.contact.id) },
+                            trailingAction = contactRowTrailingAction?.let { action -> {
+                                coroutineScope.launch {
+                                    action.onClick(item.contact)
+                                    onOpenSettingsSubpage(action.settingsSubpageIndex, null)
+                                }
+                            } },
+                            trailingContent = contactRowTrailingAction?.content,
                         )
                     }
                 }
@@ -282,6 +303,8 @@ private fun ContactRow(
     roundTop: Boolean,
     roundBottom: Boolean,
     onOpenContact: () -> Unit,
+    trailingAction: (() -> Unit)? = null,
+    trailingContent: (@Composable () -> Unit)? = null,
 ) {
     Surface(
         onClick = onOpenContact,
@@ -316,6 +339,12 @@ private fun ContactRow(
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            if (trailingAction != null && trailingContent != null) {
+                androidx.compose.foundation.layout.Spacer(modifier = Modifier.weight(1f))
+                IconButton(onClick = trailingAction) {
+                    trailingContent()
+                }
+            }
         }
     }
 }

--- a/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/ContactsSearchScreen.kt
+++ b/feature/contactsSearch/src/main/java/dev/alenajam/opendialer/feature/contactsSearch/ContactsSearchScreen.kt
@@ -21,9 +21,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.Backspace
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -31,7 +28,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -656,8 +652,8 @@ private fun Footer(
                         onClick = { overflowExpanded = true },
                         enabled = query.isNotBlank()
                     ) {
-                        Icon(
-                            imageVector = Icons.Default.MoreVert,
+                        AppIcon(
+                            icon = LocalAppIcons.current.more,
                             contentDescription = stringResource(R.string.dialpad_more_options)
                         )
                     }
@@ -714,8 +710,8 @@ private fun Footer(
                             }
                         )
                 ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Outlined.Backspace,
+                    AppIcon(
+                        icon = LocalAppIcons.current.backspace,
                         contentDescription = stringResource(R.string.backspace)
                     )
                 }

--- a/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/Footer.kt
+++ b/feature/inCall/src/main/java/dev/alenajam/opendialer/feature/inCall/ui/Footer.kt
@@ -18,9 +18,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Close
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -141,7 +138,10 @@ fun InCallControls(
                         IconButton(
                             onClick = { toggleSectionButton(OpenSection.ADDITIONAL_ACTIONS) }
                         ) {
-                            Icon(imageVector = Icons.Outlined.Close, contentDescription = stringResource(R.string.action_close))
+                            AppIcon(
+                                icon = icons.close,
+                                contentDescription = stringResource(R.string.action_close),
+                            )
                         }
                     }
 
@@ -191,7 +191,10 @@ fun InCallControls(
                         IconButton(
                             onClick = { toggleSectionButton(OpenSection.DIALPAD) }
                         ) {
-                            Icon(imageVector = Icons.Outlined.Close, contentDescription = stringResource(R.string.action_close))
+                            AppIcon(
+                                icon = icons.close,
+                                contentDescription = stringResource(R.string.action_close),
+                            )
                         }
                     }
 

--- a/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/AboutScreen.kt
+++ b/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/AboutScreen.kt
@@ -193,27 +193,42 @@ fun AboutScreen(
             val fontName = stringResource(R.string.font_name)
             val fontAuthor = stringResource(R.string.font_author)
             val fontUri = stringResource(R.string.url_font)
-            if (fontName.isNotBlank() && fontAuthor.isNotBlank()) {
+            val iconDesigner = stringResource(R.string.icon_designer)
+            val iconDesignerUri = stringResource(R.string.url_icon_designer)
+            val hasFontCredit = fontName.isNotBlank() && fontAuthor.isNotBlank()
+            val hasIconCredit = iconDesigner.isNotBlank()
+            if (hasFontCredit || hasIconCredit) {
                 Text(
                     modifier = Modifier.padding(top = 4.dp),
                     text = stringResource(R.string.about_section_credits),
                     style = MaterialTheme.typography.titleMedium
                 )
-                if (fontUri.isBlank()) {
-                    AboutInfoCard(
-                        title = stringResource(R.string.typography_credit_title),
-                        description = stringResource(R.string.font_credit_format, fontName, fontAuthor),
-                        roundTop = true,
-                        roundBottom = true
-                    )
-                } else {
-                    AboutLinkCard(
-                        title = stringResource(R.string.typography_credit_title),
-                        description = stringResource(R.string.font_credit_format, fontName, fontAuthor),
-                        uri = fontUri,
-                        roundTop = true,
-                        roundBottom = true
-                    )
+                Column {
+                    if (hasFontCredit && fontUri.isBlank()) {
+                        AboutInfoCard(
+                            title = stringResource(R.string.typography_credit_title),
+                            description = stringResource(R.string.font_credit_format, fontName, fontAuthor),
+                            roundTop = true,
+                            roundBottom = !hasIconCredit
+                        )
+                    } else if (hasFontCredit) {
+                        AboutLinkCard(
+                            title = stringResource(R.string.typography_credit_title),
+                            description = stringResource(R.string.font_credit_format, fontName, fontAuthor),
+                            uri = fontUri,
+                            roundTop = true,
+                            roundBottom = !hasIconCredit
+                        )
+                    }
+                    if (hasIconCredit) {
+                        AboutLinkCard(
+                            title = stringResource(R.string.icon_credit_title),
+                            description = stringResource(R.string.icon_credit_format, iconDesigner),
+                            uri = iconDesignerUri,
+                            roundTop = !hasFontCredit,
+                            roundBottom = true
+                        )
+                    }
                 }
             }
         }

--- a/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/Routes.kt
+++ b/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/Routes.kt
@@ -15,7 +15,7 @@ data object QuickResponsesRoute
 data object DisplayOptionsRoute
 
 @Serializable
-data class SettingsSubpageRoute(val index: Int)
+data class SettingsSubpageRoute(val index: Int, val payload: String? = null)
 
 @Serializable
 data class SettingsSubpageDestinationRoute(

--- a/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsScreen.kt
@@ -55,7 +55,7 @@ fun SettingsScreen(
     onOpenQuickResponses: () -> Unit = {},
     onOpenDisplayOptions: () -> Unit = {},
     subpages: List<SettingsSubpage> = emptyList(),
-    onOpenSubpage: (Int) -> Unit = {}
+    onOpenSubpage: (Int, String?) -> Unit = { _, _ -> }
 ) {
     val context = LocalContext.current
     var updateChecksEnabled by remember {
@@ -111,7 +111,7 @@ fun SettingsScreen(
     }
     val extensionItems = subpages.mapIndexedNotNull { index, page ->
         if (!page.visibleInSettings) return@mapIndexedNotNull null
-        SettingsListItem(page.title, page.description) { onOpenSubpage(index) }
+        SettingsListItem(page.title, page.description) { onOpenSubpage(index, null) }
     }
     Scaffold(
         topBar = {

--- a/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsSubpage.kt
+++ b/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsSubpage.kt
@@ -12,16 +12,20 @@ data class SettingsSubpageDestination(
 )
 
 class SettingsSubpageNavigator internal constructor(
-    private val navigateToDestination: (Int, String?) -> Unit
+    private val navigateToDestination: (Int, String?) -> Unit,
+    private val onNavigateBack: () -> Unit
 ) {
     fun navigateTo(destinationIndex: Int, payload: String? = null) = 
         navigateToDestination(destinationIndex, payload)
+
+    fun navigateBack() = onNavigateBack()
 }
 
 data class SettingsSubpage(
     val title: String,
     val description: String? = null,
     val subtitle: String? = null,
+    val topBarTitle: (@Composable () -> Unit)? = null,
     val content: @Composable ColumnScope.() -> Unit,
     val actions: @Composable RowScope.() -> Unit = {},
     val isScrollable: Boolean = true,

--- a/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsSubpage.kt
+++ b/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsSubpage.kt
@@ -26,7 +26,7 @@ data class SettingsSubpage(
     val description: String? = null,
     val subtitle: String? = null,
     val topBarTitle: (@Composable () -> Unit)? = null,
-    val content: @Composable ColumnScope.() -> Unit,
+    val content: @Composable ColumnScope.(payload: String?) -> Unit,
     val actions: @Composable RowScope.() -> Unit = {},
     val isScrollable: Boolean = true,
     val topContentPadding: Dp = 16.dp,

--- a/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsSubpageScreen.kt
+++ b/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsSubpageScreen.kt
@@ -29,6 +29,7 @@ val LocalSettingsSubpageNavigator = staticCompositionLocalOf<SettingsSubpageNavi
 @Composable
 fun SettingsSubpageScreen(
     page: SettingsSubpage,
+    payload: String?,
     onNavigateBack: () -> Unit,
     onNavigateToDestination: (Int, String?) -> Unit
 ) {
@@ -62,7 +63,7 @@ fun SettingsSubpageScreen(
                     if (page.isScrollable) modifier.verticalScroll(rememberScrollState()) else modifier
                 }
             Column(modifier = contentModifier) {
-                page.content(this@Column)
+                page.content(this@Column, payload)
             }
         }
     }

--- a/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsSubpageScreen.kt
+++ b/feature/settings/src/main/java/dev/alenajam/opendialer/feature/settings/SettingsSubpageScreen.kt
@@ -33,18 +33,20 @@ fun SettingsSubpageScreen(
     onNavigateToDestination: (Int, String?) -> Unit
 ) {
     CompositionLocalProvider(
-        LocalSettingsSubpageNavigator provides SettingsSubpageNavigator(onNavigateToDestination)
+        LocalSettingsSubpageNavigator provides SettingsSubpageNavigator(onNavigateToDestination, onNavigateBack)
     ) {
         Scaffold(topBar = {
             TopAppBar(title = {
-                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    Text(page.title)
-                    page.subtitle?.let { subtitle ->
-                        Text(
-                            subtitle,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                page.topBarTitle?.invoke() ?: run {
+                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        Text(page.title)
+                        page.subtitle?.let { subtitle ->
+                            Text(
+                                subtitle,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                 }
             }, navigationIcon = {

--- a/feature/settings/src/main/res/values-ar/strings.xml
+++ b/feature/settings/src/main/res/values-ar/strings.xml
@@ -40,4 +40,6 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">هل وجدت خطأ أو لديك فكرة؟ افتح بلاغًا على GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">تواصل</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s من تصميم %2$s</string>
+    <string name="icon_credit_title" comment="Title of the icon-design credit card on the About screen.">تصميم الأيقونات</string>
+    <string name="icon_credit_format" comment="Icon credit. %1$s is the icon designer.">أيقونات من تصميم %1$s</string>
 </resources>

--- a/feature/settings/src/main/res/values-da/strings.xml
+++ b/feature/settings/src/main/res/values-da/strings.xml
@@ -40,4 +40,6 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Har du fundet en fejl eller fået en idé? Opret en sag på GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Kontakt</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s af %2$s</string>
+    <string name="icon_credit_title" comment="Title of the icon-design credit card on the About screen.">Ikondesign</string>
+    <string name="icon_credit_format" comment="Icon credit. %1$s is the icon designer.">Ikoner af %1$s</string>
 </resources>

--- a/feature/settings/src/main/res/values-de/strings.xml
+++ b/feature/settings/src/main/res/values-de/strings.xml
@@ -40,4 +40,6 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Du hast einen Fehler gefunden oder eine Idee? Erstelle ein Issue auf GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Kontakt</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s von %2$s</string>
+    <string name="icon_credit_title" comment="Title of the icon-design credit card on the About screen.">Icon-Design</string>
+    <string name="icon_credit_format" comment="Icon credit. %1$s is the icon designer.">Icons von %1$s</string>
 </resources>

--- a/feature/settings/src/main/res/values-es/strings.xml
+++ b/feature/settings/src/main/res/values-es/strings.xml
@@ -40,4 +40,6 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">¿Has encontrado un error o tienes una idea? Abre una incidencia en GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Contacto</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s de %2$s</string>
+    <string name="icon_credit_title" comment="Title of the icon-design credit card on the About screen.">Diseño de iconos</string>
+    <string name="icon_credit_format" comment="Icon credit. %1$s is the icon designer.">Iconos de %1$s</string>
 </resources>

--- a/feature/settings/src/main/res/values-fr/strings.xml
+++ b/feature/settings/src/main/res/values-fr/strings.xml
@@ -40,4 +40,6 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Vous avez trouvé un bug ou vous avez une idée ? Ouvrez un ticket sur GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Contact</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s par %2$s</string>
+    <string name="icon_credit_title" comment="Title of the icon-design credit card on the About screen.">Conception des icônes</string>
+    <string name="icon_credit_format" comment="Icon credit. %1$s is the icon designer.">Icônes par %1$s</string>
 </resources>

--- a/feature/settings/src/main/res/values-it/strings.xml
+++ b/feature/settings/src/main/res/values-it/strings.xml
@@ -40,4 +40,6 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Hai trovato un problema o hai un’idea? Apri una segnalazione su GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Contatti</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s di %2$s</string>
+    <string name="icon_credit_title" comment="Title of the icon-design credit card on the About screen.">Progettazione icone</string>
+    <string name="icon_credit_format" comment="Icon credit. %1$s is the icon designer.">Icone di %1$s</string>
 </resources>

--- a/feature/settings/src/main/res/values-nb/strings.xml
+++ b/feature/settings/src/main/res/values-nb/strings.xml
@@ -40,4 +40,6 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Har du funnet en feil eller har en idé? Opprett en sak på GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Kontakt</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s av %2$s</string>
+    <string name="icon_credit_title" comment="Title of the icon-design credit card on the About screen.">Ikondesign</string>
+    <string name="icon_credit_format" comment="Icon credit. %1$s is the icon designer.">Ikoner av %1$s</string>
 </resources>

--- a/feature/settings/src/main/res/values-nl/strings.xml
+++ b/feature/settings/src/main/res/values-nl/strings.xml
@@ -37,6 +37,8 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Een fout gevonden of een idee? Open een issue op GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Contact</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s door %2$s</string>
+    <string name="icon_credit_title" comment="Title of the icon-design credit card on the About screen.">Icoonontwerp</string>
+    <string name="icon_credit_format" comment="Icon credit. %1$s is the icon designer.">Pictogrammen door %1$s</string>
     <string name="update_checks">Updates</string>
     <string name="check_for_updates">Controleren op updates</string>
     <string name="check_for_updates_description">Zoek op GitHub naar nieuwe versies</string>

--- a/feature/settings/src/main/res/values-pt/strings.xml
+++ b/feature/settings/src/main/res/values-pt/strings.xml
@@ -40,4 +40,6 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Encontrou um erro ou teve uma ideia? Abra uma issue no GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Contato</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s por %2$s</string>
+    <string name="icon_credit_title" comment="Title of the icon-design credit card on the About screen.">Design de ícones</string>
+    <string name="icon_credit_format" comment="Icon credit. %1$s is the icon designer.">Ícones por %1$s</string>
 </resources>

--- a/feature/settings/src/main/res/values-ro/strings.xml
+++ b/feature/settings/src/main/res/values-ro/strings.xml
@@ -40,4 +40,6 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">Ai găsit o eroare sau ai o idee? Deschide o sesizare pe GitHub.</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">Contact</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s de %2$s</string>
+    <string name="icon_credit_title" comment="Title of the icon-design credit card on the About screen.">Design pictograme</string>
+    <string name="icon_credit_format" comment="Icon credit. %1$s is the icon designer.">Pictograme de %1$s</string>
 </resources>

--- a/feature/settings/src/main/res/values-zh/strings.xml
+++ b/feature/settings/src/main/res/values-zh/strings.xml
@@ -40,4 +40,6 @@
     <string name="issues_description" comment="Description of the issue-reporting link on the About screen.">发现错误或有新想法？请在 GitHub 上提交问题。</string>
     <string name="contact_developer" comment="Title of the developer email link on the About screen.">联系方式</string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s，作者：%2$s</string>
+    <string name="icon_credit_title" comment="Title of the icon-design credit card on the About screen.">图标设计</string>
+    <string name="icon_credit_format" comment="Icon credit. %1$s is the icon designer.">图标设计：%1$s</string>
 </resources>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -58,4 +58,8 @@
     <string name="font_author" translatable="false"></string>
     <string name="url_font" translatable="false"></string>
     <string name="font_credit_format" comment="Font credit. %1$s is the font name and %2$s is the font author.">%1$s by %2$s</string>
+    <string name="icon_credit_title" comment="Title of the icon-design credit card on the About screen.">Icon design</string>
+    <string name="icon_designer" translatable="false"></string>
+    <string name="url_icon_designer" translatable="false"></string>
+    <string name="icon_credit_format" comment="Icon credit. %1$s is the icon designer.">Icons by %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- add an optional icon-design credit to the shared About screen
- localize the credit title and format across supported locales
- allow apps to provide a designer name and profile URL

## Verification
- ./gradlew :app:compileDebugKotlin