### PR TITLE
feat(contacts): add fast scrolling to contact lists

### DIFF
--- a/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/AddFavoriteScreen.kt
+++ b/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/AddFavoriteScreen.kt
@@ -3,6 +3,7 @@ package dev.alenajam.opendialer.feature.contacts
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -114,6 +116,7 @@ fun ContactPickerScreen(
                 }
         }
     }
+    val listState = rememberLazyListState()
 
     LaunchedEffect(isSearching) {
         if (isSearching) searchFocusRequester.requestFocus() else focusManager.clearFocus()
@@ -193,7 +196,8 @@ fun ContactPickerScreen(
                     requestPermissions = { requestPermissions.launch(PermissionUtils.contactsPermissions) }
                 )
             } else {
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
                     items(items) { item ->
                         when (item) {
                             is ContactListItem.Header -> {
@@ -209,6 +213,12 @@ fun ContactPickerScreen(
                             }
                         }
                     }
+                    }
+                    ContactFastScroller(
+                        listState = listState,
+                        contentDescription = stringResource(R.string.fast_scroll_contacts),
+                        modifier = Modifier.align(Alignment.CenterEnd).padding(vertical = 8.dp),
+                    )
                 }
             }
         }

--- a/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/ContactsScreen.kt
+++ b/feature/contacts/src/main/java/dev/alenajam/opendialer/feature/contacts/ContactsScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,6 +15,10 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.background
 import androidx.compose.material.icons.Icons
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
@@ -27,10 +32,21 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -85,6 +101,7 @@ fun ContactsScreen(
             favoritesLabel = favoritesLabel,
         )
     }
+    val listState = rememberLazyListState()
 
     Surface(modifier = Modifier.fillMaxSize()) {
         if (!hasPermission.value) {
@@ -108,9 +125,11 @@ fun ContactsScreen(
             return@Surface
         }
 
-        LazyColumn(
-            contentPadding = PaddingValues(bottom = 88.dp),
-        ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            LazyColumn(
+                state = listState,
+                contentPadding = PaddingValues(bottom = 88.dp),
+            ) {
             if (searchQuery.isBlank()) {
                 item(key = "new-contact") {
                     Button(
@@ -160,7 +179,57 @@ fun ContactsScreen(
                     }
                 }
             }
+            }
+            ContactFastScroller(
+                listState = listState,
+                contentDescription = stringResource(R.string.fast_scroll_contacts),
+                modifier = Modifier.align(Alignment.CenterEnd).padding(vertical = 8.dp),
+            )
         }
+    }
+}
+
+@Composable
+internal fun ContactFastScroller(
+    listState: LazyListState,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+) {
+    val layoutInfo = listState.layoutInfo
+    val visibleItemCount = layoutInfo.visibleItemsInfo.size
+    val totalItemCount = layoutInfo.totalItemsCount
+    if (totalItemCount <= 12 || totalItemCount <= visibleItemCount * 2) return
+
+    val position = (listState.firstVisibleItemIndex.toFloat() /
+        (totalItemCount - visibleItemCount).coerceAtLeast(1)).coerceIn(0f, 1f)
+    val scope = rememberCoroutineScope()
+    BoxWithConstraints(
+        modifier = modifier
+            .width(40.dp)
+            .fillMaxHeight()
+            .semantics { this.contentDescription = contentDescription }
+            .pointerInput(Unit) {
+                detectDragGestures(
+                    onDragStart = { offset ->
+                        scope.launch { listState.requestScrollToItem((offset.y / size.height * (totalItemCount - visibleItemCount).coerceAtLeast(0)).roundToInt()) }
+                    },
+                    onDrag = { change, _ ->
+                        scope.launch { listState.requestScrollToItem((change.position.y / size.height * (totalItemCount - visibleItemCount).coerceAtLeast(0)).roundToInt()) }
+                    },
+                )
+            },
+    ) {
+        val thumbHeight = (maxHeight * (visibleItemCount.toFloat() / totalItemCount)).coerceIn(48.dp, maxHeight)
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(vertical = 8.dp)
+                .width(6.dp)
+                .height(thumbHeight)
+                .offset(y = (maxHeight - thumbHeight).coerceAtLeast(0.dp) * position)
+                .clip(RoundedCornerShape(4.dp))
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.7f)),
+        )
     }
 }
 

--- a/feature/contacts/src/main/res/values-ar/strings.xml
+++ b/feature/contacts/src/main/res/values-ar/strings.xml
@@ -11,6 +11,7 @@
     <string name="search_contacts" comment="Search field hint or action for finding contacts.">البحث في جهات الاتصال</string>
     <string name="close_search" comment="Accessibility label for closing contact search.">إغلاق البحث</string>
     <string name="choose_contact" comment="Title of a screen or dialog where the user selects a contact.">اختر جهة اتصال</string>
+    <string name="fast_scroll_contacts" comment="Accessibility label for the draggable fast-scrolling control in contact lists.">تمرير سريع لجهات الاتصال</string>
     <string name="navigate_back" comment="Accessibility label for navigating to the previous screen.">رجوع</string>
     <string name="search" comment="Accessibility label for starting a search.">بحث</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">المفضلة</string>

--- a/feature/contacts/src/main/res/values-da/strings.xml
+++ b/feature/contacts/src/main/res/values-da/strings.xml
@@ -11,6 +11,7 @@
     <string name="search_contacts" comment="Search field hint or action for finding contacts.">Søg i kontakter</string>
     <string name="close_search" comment="Accessibility label for closing contact search.">Luk søgning</string>
     <string name="choose_contact" comment="Title of a screen or dialog where the user selects a contact.">Vælg en kontakt</string>
+    <string name="fast_scroll_contacts" comment="Accessibility label for the draggable fast-scrolling control in contact lists.">Hurtig rulning i kontakter</string>
     <string name="navigate_back" comment="Accessibility label for navigating to the previous screen.">Tilbage</string>
     <string name="search" comment="Accessibility label for starting a search.">Søg</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favoritter</string>

--- a/feature/contacts/src/main/res/values-de/strings.xml
+++ b/feature/contacts/src/main/res/values-de/strings.xml
@@ -11,6 +11,7 @@
     <string name="search_contacts" comment="Search field hint or action for finding contacts.">Kontakte durchsuchen</string>
     <string name="close_search" comment="Accessibility label for closing contact search.">Suche schließen</string>
     <string name="choose_contact" comment="Title of a screen or dialog where the user selects a contact.">Kontakt auswählen</string>
+    <string name="fast_scroll_contacts" comment="Accessibility label for the draggable fast-scrolling control in contact lists.">Kontakte schnell scrollen</string>
     <string name="navigate_back" comment="Accessibility label for navigating to the previous screen.">Zurück</string>
     <string name="search" comment="Accessibility label for starting a search.">Suchen</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favoriten</string>

--- a/feature/contacts/src/main/res/values-es/strings.xml
+++ b/feature/contacts/src/main/res/values-es/strings.xml
@@ -11,6 +11,7 @@
     <string name="search_contacts" comment="Search field hint or action for finding contacts.">Buscar contactos</string>
     <string name="close_search" comment="Accessibility label for closing contact search.">Cerrar búsqueda</string>
     <string name="choose_contact" comment="Title of a screen or dialog where the user selects a contact.">Elige un contacto</string>
+    <string name="fast_scroll_contacts" comment="Accessibility label for the draggable fast-scrolling control in contact lists.">Desplazamiento rápido por los contactos</string>
     <string name="navigate_back" comment="Accessibility label for navigating to the previous screen.">Atrás</string>
     <string name="search" comment="Accessibility label for starting a search.">Buscar</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favoritos</string>

--- a/feature/contacts/src/main/res/values-fr/strings.xml
+++ b/feature/contacts/src/main/res/values-fr/strings.xml
@@ -11,6 +11,7 @@
     <string name="search_contacts" comment="Search field hint or action for finding contacts.">Rechercher des contacts</string>
     <string name="close_search" comment="Accessibility label for closing contact search.">Fermer la recherche</string>
     <string name="choose_contact" comment="Title of a screen or dialog where the user selects a contact.">Choisir un contact</string>
+    <string name="fast_scroll_contacts" comment="Accessibility label for the draggable fast-scrolling control in contact lists.">Faire défiler rapidement les contacts</string>
     <string name="navigate_back" comment="Accessibility label for navigating to the previous screen.">Retour</string>
     <string name="search" comment="Accessibility label for starting a search.">Rechercher</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favoris</string>

--- a/feature/contacts/src/main/res/values-it/strings.xml
+++ b/feature/contacts/src/main/res/values-it/strings.xml
@@ -11,6 +11,7 @@
     <string name="search_contacts" comment="Search field hint or action for finding contacts.">Cerca contatti</string>
     <string name="close_search" comment="Accessibility label for closing contact search.">Chiudi ricerca</string>
     <string name="choose_contact" comment="Title of a screen or dialog where the user selects a contact.">Scegli un contatto</string>
+    <string name="fast_scroll_contacts" comment="Accessibility label for the draggable fast-scrolling control in contact lists.">Scorri rapidamente i contatti</string>
     <string name="navigate_back" comment="Accessibility label for navigating to the previous screen.">Indietro</string>
     <string name="search" comment="Accessibility label for starting a search.">Cerca</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Preferiti</string>

--- a/feature/contacts/src/main/res/values-nb/strings.xml
+++ b/feature/contacts/src/main/res/values-nb/strings.xml
@@ -11,6 +11,7 @@
     <string name="search_contacts" comment="Search field hint or action for finding contacts.">Søk i kontakter</string>
     <string name="close_search" comment="Accessibility label for closing contact search.">Lukk søket</string>
     <string name="choose_contact" comment="Title of a screen or dialog where the user selects a contact.">Velg en kontakt</string>
+    <string name="fast_scroll_contacts" comment="Accessibility label for the draggable fast-scrolling control in contact lists.">Bla raskt gjennom kontakter</string>
     <string name="navigate_back" comment="Accessibility label for navigating to the previous screen.">Tilbake</string>
     <string name="search" comment="Accessibility label for starting a search.">Søk</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favoritter</string>

--- a/feature/contacts/src/main/res/values-nl/strings.xml
+++ b/feature/contacts/src/main/res/values-nl/strings.xml
@@ -11,6 +11,7 @@
     <string name="search_contacts" comment="Search field hint or action for finding contacts.">Contacten zoeken</string>
     <string name="close_search" comment="Accessibility label for closing contact search.">Zoeken sluiten</string>
     <string name="choose_contact" comment="Title of a screen or dialog where the user selects a contact.">Kies een contact</string>
+    <string name="fast_scroll_contacts" comment="Accessibility label for the draggable fast-scrolling control in contact lists.">Snel door contacten scrollen</string>
     <string name="navigate_back" comment="Accessibility label for navigating to the previous screen.">Terug</string>
     <string name="search" comment="Accessibility label for starting a search.">Zoeken</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favorieten</string>

--- a/feature/contacts/src/main/res/values-pt/strings.xml
+++ b/feature/contacts/src/main/res/values-pt/strings.xml
@@ -11,6 +11,7 @@
     <string name="search_contacts" comment="Search field hint or action for finding contacts.">Pesquisar contatos</string>
     <string name="close_search" comment="Accessibility label for closing contact search.">Fechar pesquisa</string>
     <string name="choose_contact" comment="Title of a screen or dialog where the user selects a contact.">Escolha um contato</string>
+    <string name="fast_scroll_contacts" comment="Accessibility label for the draggable fast-scrolling control in contact lists.">Percorrer contatos rapidamente</string>
     <string name="navigate_back" comment="Accessibility label for navigating to the previous screen.">Voltar</string>
     <string name="search" comment="Accessibility label for starting a search.">Pesquisar</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favoritos</string>

--- a/feature/contacts/src/main/res/values-ro/strings.xml
+++ b/feature/contacts/src/main/res/values-ro/strings.xml
@@ -11,6 +11,7 @@
     <string name="search_contacts" comment="Search field hint or action for finding contacts.">Caută contacte</string>
     <string name="close_search" comment="Accessibility label for closing contact search.">Închide căutarea</string>
     <string name="choose_contact" comment="Title of a screen or dialog where the user selects a contact.">Alege un contact</string>
+    <string name="fast_scroll_contacts" comment="Accessibility label for the draggable fast-scrolling control in contact lists.">Derulare rapidă prin contacte</string>
     <string name="navigate_back" comment="Accessibility label for navigating to the previous screen.">Înapoi</string>
     <string name="search" comment="Accessibility label for starting a search.">Caută</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favorite</string>

--- a/feature/contacts/src/main/res/values-zh/strings.xml
+++ b/feature/contacts/src/main/res/values-zh/strings.xml
@@ -11,6 +11,7 @@
     <string name="search_contacts" comment="Search field hint or action for finding contacts.">搜索联系人</string>
     <string name="close_search" comment="Accessibility label for closing contact search.">关闭搜索</string>
     <string name="choose_contact" comment="Title of a screen or dialog where the user selects a contact.">选择联系人</string>
+    <string name="fast_scroll_contacts" comment="Accessibility label for the draggable fast-scrolling control in contact lists.">快速滚动联系人</string>
     <string name="navigate_back" comment="Accessibility label for navigating to the previous screen.">返回</string>
     <string name="search" comment="Accessibility label for starting a search.">搜索</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">收藏</string>

--- a/feature/contacts/src/main/res/values/strings.xml
+++ b/feature/contacts/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="search_contacts" comment="Search field hint or action for finding contacts.">Search contacts</string>
     <string name="close_search" comment="Accessibility label for closing contact search.">Close search</string>
     <string name="choose_contact" comment="Title of a screen or dialog where the user selects a contact.">Choose a contact</string>
+    <string name="fast_scroll_contacts" comment="Accessibility label for the draggable fast-scrolling control in contact lists.">Fast scroll contacts</string>
     <string name="navigate_back" comment="Accessibility label for navigating to the previous screen.">Back</string>
     <string name="search" comment="Accessibility label for starting a search.">Search</string>
     <string name="favorites" comment="Heading or navigation label for favorite contacts.">Favorites</string>


### PR DESCRIPTION
## Summary
- Add a draggable fast-scroller to the main contacts list.
- Add the fast-scroller to the Add Favorite contact picker.
- Add localized fast-scroll accessibility labels for all supported languages.
- Use a thicker 6dp thumb with a larger touch target.

## Related PR
MonsterDialer integration: https://github.com/oxcened/monster-dialer/pull/45

## Verification
The integrated MonsterDialer build passes with these changes included: :app:compileDebugKotlin